### PR TITLE
fix error in help message

### DIFF
--- a/developers_chamber/click/options.py
+++ b/developers_chamber/click/options.py
@@ -25,6 +25,8 @@ class RequiredIfNotEmpty(click.Option):
 
 class ContainerDirToCopyType(click.ParamType):
 
+    name = 'container_dir_to_copy'
+
     def convert(self, value, param, ctx):
         try:
             container_name, container_dir, host_dir = value.split(':')
@@ -40,6 +42,8 @@ class ContainerDirToCopyType(click.ParamType):
 
 
 class ContainerCommandType(click.ParamType):
+
+    name = 'container_command_type'
 
     def convert(self, value, param, ctx):
         try:


### PR DESCRIPTION
Error was occurring because of missing attribute `name` in classes ContainerDirToCopyType and  ContainerCommandType which is required by Click to render help message. 

It is incorrectly stated in the Click docs that the attribute is optional.
https://click.palletsprojects.com/en/7.x/parameters/#implementing-custom-types

In the Click code however these are the requirements for a valid ParamType classes

Helper for converting values through types.  The following is necessary for a valid type:
    *   it needs a name
    *   it needs to pass through None unchanged
    *   it needs to convert from a string
    *   it needs to convert its result type through unchanged
        (eg: needs to be idempotent)
    *   it needs to be able to deal with param and context being `None`.
        This can be the case when the object is used with prompt
        inputs.

https://github.com/pallets/click/blob/master/click/types.py