### PR TITLE
fix error when environment var PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY is missing in config

### DIFF
--- a/developers_chamber/scripts/project.py
+++ b/developers_chamber/scripts/project.py
@@ -31,7 +31,10 @@ default_var_dirs = (
     os.environ.get('PROJECT_DOCKER_COMPOSE_VAR_DIRS').split(',')
     if os.environ.get('PROJECT_DOCKER_COMPOSE_VAR_DIRS') else None
 )
-default_containers_dir_to_copy = os.environ.get('PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY', '').split(',')
+default_containers_dir_to_copy = (
+    os.environ.get('PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY').split(',')
+    if os.environ.get('PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY') else None
+)
 default_containers_install_command = os.environ.get('PROJECT_DOCKER_COMPOSE_CONTAINERS_INSTALL_COMMAND', '').split(',')
 
 
@@ -61,7 +64,7 @@ def set_domain(domain):
 @click.option('--container-dir-to-copy', '-d',
               help='Container dir which will be copied after build in format '
                    'DOCKER_CONTAINER_NAME:CONTAINER_DIRECTORY:HOST_DIRECTORY',
-              type=ContainerDirToCopyType(), required=True, multiple=True, default=default_containers_dir_to_copy)
+              type=ContainerDirToCopyType(), multiple=True, default=default_containers_dir_to_copy)
 def build(project_name, compose_file, container, container_dir_to_copy):
     """
     Build docker container


### PR DESCRIPTION
This pull request modifies the `project` command group:
1) removes `required=True` from `--container-dir-to-copy` option on `build` command as there is already a default value set and it generates errors when the option is omitted
2) fix errors when the environment variable `PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY` is not in the config

These errors caused the CI builds to fail as there is no need to copy any directories for the build in CI pipeline.