### PR TITLE
get the version from ENV of docker hub

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM docker:stable-dind
 
+ARG VERSION
+ENV DOCKER_TAG=${VERSION}
 RUN apk update && apk add git python3 python3-dev libffi-dev openssl-dev gcc libc-dev make gettext openssl-dev bash openssh 
-RUN pip3 install --upgrade urllib3==1.24.3 awscli==1.16.241 requests==2.22.0 docker-compose developers-chamber==0.0.19
+RUN pip3 install --upgrade urllib3==1.24.3 awscli==1.16.241 requests==2.22.0 docker-compose https://github.com/druids/developers-chamber/tarball/${DOCKER_TAG}
 
 ENTRYPOINT ["bash", "-c"]
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,9 @@
+# Docker image for developers-chamber
+
+To build the docker image manually use the VERSION build argument to specify developers-chamber version
+The version is based on tags on github
+
+Example:
+```
+docker build --build-arg VERSION=0.0.20 .
+```

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --build-arg VERSION=${DOCKER_TAG} -f ${DOCKERFILE_PATH} -t ${IMAGE_NAME} .


### PR DESCRIPTION
In addition to configuration on Docker Hub this triggers automatic builds of developers-chamber docker image with version taken from the git TAG. This overrides the installation of developers-chamber package from pypi and installs it directly from Github to avoid race condition.