### PR TITLE
Update togglpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'click-completion==0.5.2',
         'jira==2.0.0',
         'unidecode==1.1.1',
-        'TogglPy==0.1.1',
+        'TogglPy==0.1.2',
         'attrdict==2.0.1',
     ],
     entry_points={'console_scripts': [


### PR DESCRIPTION
Starting on Nov 8, 2021., the use of the old public API domain (toggl.com) has been dropped in favor of the new api.track.toggl.com domain. Any custom integration relying on the old Toggl domain will either stop working completely or become very functionally limited.

The update library takes care of that.