### PR TITLE
fix(Dockerfile): remove duplicit package listing and explicit openssh install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,6 @@ RUN apk update && \
 	libc-dev \
 	libffi-dev \
 	make \
-	openssh \
-	openssl-dev \
 	openssl-dev \
 	py3-cryptography \
 	py3-pip \


### PR DESCRIPTION
OpenSSH is already contained in the resulting image.