### PR TITLE
Update isort==5.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name='developers-chamber',
@@ -20,7 +20,7 @@ setup(
         'python-dotenv==0.14.0',
         'boto3<2',
         'python-hosts==0.4.6',
-        'isort==4.3.21',
+        'isort==5.12.0',
         'coloredlogs==10.0',
         'click-completion==0.5.2',
         'jira==2.0.0',
@@ -31,5 +31,5 @@ setup(
     entry_points={'console_scripts': [
         'pydev=developers_chamber.bin.pydev:cli',
     ]},
-    zip_safe=False
+    zip_safe=False,
 )


### PR DESCRIPTION
Updating `isort` to version 5 brings a lot of new features/options that may come in handy. 

Check out the [release page](https://pycqa.github.io/isort/docs/major_releases/introducing_isort_5.html) for more info.

For example, If I had the `--filename` option I would be very happy as I wouldn't need to downgrade a plugin my editor uses to format code on save.

Also, I used `isort` on `setup.py`.

There are also some implications for the configuration of package users:
* `THIRD_PARTY` -> `THIRDPARTY`
* A lot of complaining when X is defined in `section` but the `known_x` section is not defined. 