### PR TITLE
qa check: ignore term formatting chars

### DIFF
--- a/developers_chamber/qa/checks.py
+++ b/developers_chamber/qa/checks.py
@@ -17,8 +17,7 @@ class MissingMigrationsQACheck(QACheck):
         output = self._run_command(
             '{}{}'.format(self._get_command_from_config('QA_MAKE_MIGRATIONS_COMMAND'), ' --dry-run')
         )
-        last_line = output.split('\n')[-1]
-        if last_line != 'No changes detected':
+        if not re.search('No changes detected', output):
             raise QAError(
                 'Found missing migration(s)!',
                 re.findall(r'Migrations.+$', remove_ansi(output), re.DOTALL)[0]


### PR DESCRIPTION
during `pydev qa all` I got following error:
```
root[7673] INFO [1/6] Check missing migrations...
root[7680] INFO docker-compose -p core -fdocker/compose/docker-compose.yml -fdocker/compose/docker-compose.local.yml -fdocker/compose/docker-compose.local.var.yml run --use-aliases admin ./manage.py makemigrations $apps --name=migration --dry-run
WARNING: The REGISTRY_PREFIX variable is not set. Defaulting to a blank string.
WARNING: The COMPOSE_USER variable is not set. Defaulting to a blank string.
Creating core_admin_run ... done
Traceback (most recent call last):
  File "/usr/local/bin/pydev", line 8, in <module>
    sys.exit(cli())
  File "/Library/Python/3.9/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Library/Python/3.9/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Library/Python/3.9/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Library/Python/3.9/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Library/Python/3.9/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Library/Python/3.9/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/chuan/Library/Python/3.9/lib/python/site-packages/developers_chamber/scripts/qa.py", line 22, in all
    QACheckRunner(
  File "/Users/chuan/Library/Python/3.9/lib/python/site-packages/developers_chamber/qa/base.py", line 172, in run
    self._run_checks()
  File "/Users/chuan/Library/Python/3.9/lib/python/site-packages/developers_chamber/qa/base.py", line 150, in _run_checks
    check.run()
  File "/Users/chuan/Library/Python/3.9/lib/python/site-packages/developers_chamber/qa/base.py", line 117, in run
    self._run_check()
  File "/Users/chuan/Library/Python/3.9/lib/python/site-packages/developers_chamber/qa/checks.py", line 24, in _run_check
    re.findall(r'Migrations.+$', remove_ansi(output), re.DOTALL)[0]
IndexError: list index out of range
```
the `output` variable:
```
(Pdb) output.split('\n')
['[2023-03-09 03:25:51,187] <INFO> (pynamodb.settings) {f23c6f3052e7 : MainProcess-1}: Override settings for pynamo not available /etc/pynamodb/global_default_settings.py\r', '[2023-03-09 03:25:51,188] <INFO> (pynamodb.settings) {f23c6f3052e7 : MainProcess-1}: Using Default settings value\r', 'No changes detected\r', '\x1b[0m']
```
The problem is that different terminals can add special characters (color formatting) to the output and then the string full match does not work. I have changed it to regexp matching.