### PR TITLE
remove file changes instead of stashing them when qa job fails (KNJ-9372)

### DIFF
--- a/developers_chamber/qa/base.py
+++ b/developers_chamber/qa/base.py
@@ -103,7 +103,7 @@ class QACheck(RepoMixin):
         """
         Cleans up the repo to be fresh for another check.
         """
-        self._get_repo().git.stash('save')
+        self._get_repo().git.reset('--hard', 'HEAD')
 
     def _is_python_file(self, path):
         return bool(re.search(r'\.py$', path))


### PR DESCRIPTION
When `pydev qa all` failed, the command ran `git stash save`. We should instead remove the changes by calling `git reset --hard HEAD`.