### PR TITLE
Fix GitLab run_job - variable key to use 'value'

### DIFF
--- a/developers_chamber/gitlab_utils.py
+++ b/developers_chamber/gitlab_utils.py
@@ -67,7 +67,7 @@ def run_job(url, token, project, ref, variables):
             "variables": [
                 {
                     "key": key,
-                    "secret_value": value,
+                    "value": value,
                     "variable_type": "env_var",
                 }
                 for key, value in variables.items()


### PR DESCRIPTION
variable key to use 'value' instead of 'secret_value' in API payload