### PR TITLE
AddedPrefixPossibilityToRelease: add release prefix support to create…

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Docker utilities helping with managing docker in your project:
 Helpers to run git commands which simplify releasing.
 
 #### Commands
+* `pydev git create-release` - bump the version file, create a release branch, tag it and push both to the remote repository if the remote name is specified
 * `pydev git create-release-branch` - create a release branch and push it to the remote repository if the remote name is specified
 * `pydev git create-deployment-branch` - create a deployment branch and new commit to trigger a deployment event
 * `pydev git checkout-to-release-branch` - checkout git repository back to the release branch from deployment branch
@@ -176,9 +177,17 @@ Helpers to run git commands which simplify releasing.
 * `pydev git merge-release-branch` - merge current branch to the selected branch
 * `pydev git init-hooks` - initialize git hooks defined in the directory ./.pydev/git/hooks
 
+The `create-release` and `create-release-branch` commands accept `--release-prefix/-P` (default from `RELEASE_PREFIX`). When set, the prefix is joined to the version with `@`, so a monorepo can release multiple packages without collisions:
+
+| | with `--release-prefix habarico` | without prefix |
+|---|---|---|
+| branch | `release/habarico@v1.3` | `release/v1.3` |
+| tag | `habarico@1.3.0` | `1.3.0` |
+
 #### Configuration
 * `GIT_REMOTE_NAME` - remote repository name
 * `GIT_BRANCH_NAME` - source branch name for create-release-branch command
+* `RELEASE_PREFIX` - package/component prefix for the release branch name and tag (see `--release-prefix`)
 
 ### Gitlab
 

--- a/developers_chamber/git_utils.py
+++ b/developers_chamber/git_utils.py
@@ -9,7 +9,9 @@ from .types import ReleaseType, VersionFileType
 from .version_utils import bump_to_next_version, bump_version, get_version
 
 DEPLOYMENT_COMMIT_PATTERN = r'^Deployment of "(?P<branch_name>.+)"$'
-VERSION_PATTERN = r"^(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$"
+# The optional "<prefix>@" (or "<prefix>/") group lets a package-prefixed tag like
+# "habarico@1.3.0" resolve back to the bare version. Prefix-agnostic on purpose.
+VERSION_PATTERN = r"^(?:.+[@/])?(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$"
 
 
 def _repo():
@@ -18,7 +20,27 @@ def _repo():
     return git.Repo(".", search_parent_directories=True)
 
 
-def create_release_branch(version, release_type, remote_name=None, branch_name=None):
+def _release_prefix_part(release_prefix):
+    # A non-empty prefix is joined to the version with "@"; empty/whitespace means no prefix,
+    # keeping the historical naming untouched.
+    if release_prefix and release_prefix.strip():
+        return f"{release_prefix.strip()}@"
+    return ""
+
+
+def _release_branch_name(version, release_prefix=None):
+    return "release/{}v{}.{}".format(
+        _release_prefix_part(release_prefix), version.major, version.minor
+    )
+
+
+def _release_tag_name(version, release_prefix=None):
+    return f"{_release_prefix_part(release_prefix)}{version}"
+
+
+def create_release_branch(
+    version, release_type, remote_name=None, branch_name=None, release_prefix=None
+):
     repo = _repo()
     g = repo.git
 
@@ -33,7 +55,7 @@ def create_release_branch(version, release_type, remote_name=None, branch_name=N
         ReleaseType.patch,
         ReleaseType.release,
     }:
-        release_branch_name = "release/v{}".format(f"{version.major}.{version.minor}")
+        release_branch_name = _release_branch_name(version, release_prefix)
     else:
         raise BadParameter("build is not allowed for release")
     g.checkout(branch_name or "HEAD", b=release_branch_name)
@@ -50,6 +72,7 @@ def create_release(
     branch_name=None,
     file_type=None,
     pre_release=None,
+    release_prefix=None,
 ):
     repo = _repo()
     g = repo.git
@@ -80,25 +103,27 @@ def create_release(
         ReleaseType.patch,
         ReleaseType.release,
     }:
-        release_branch_name = "release/v{}".format(f"{version.major}.{version.minor}")
+        release_branch_name = _release_branch_name(version, release_prefix)
     else:
         raise BadParameter("build is not allowed for release")
+
+    release_tag_name = _release_tag_name(version, release_prefix)
 
     branch_names = [branch.name for branch in repo.branches]
     if release_branch_name in branch_names:
         g.branch("-D", release_branch_name)
 
     tags = [tag.name for tag in repo.tags]
-    if str(version) in tags:
-        g.tag("-d", str(version))
+    if release_tag_name in tags:
+        g.tag("-d", release_tag_name)
 
     g.checkout(branch_name or "HEAD", b=release_branch_name)
     g.commit(message=f"Bump version to '{version}'")
 
-    g.tag(str(version))
+    g.tag(release_tag_name)
     if remote_name:
         g.push(remote_name, release_branch_name)
-        g.push(remote_name, str(version))
+        g.push(remote_name, release_tag_name)
     return release_branch_name
 
 

--- a/developers_chamber/scripts/git.py
+++ b/developers_chamber/scripts/git.py
@@ -38,6 +38,7 @@ from .version import default_version_files, default_version_file_type
 
 default_remote_name = os.environ.get("GIT_REMOTE_NAME")
 default_branch_name = os.environ.get("GIT_BRANCH_NAME")
+default_release_prefix = os.environ.get("RELEASE_PREFIX")
 
 
 @cli.group()
@@ -84,7 +85,17 @@ def git():
     type=str,
     default=default_branch_name,
 )
-def create_release_branch(release_type, pre_release, file, remote_name, branch_name):
+@click.option(
+    "--release-prefix",
+    "-P",
+    help="package/component prefix inserted into the release branch name "
+    '(e.g. "habarico" -> release/habarico@v1.3)',
+    type=str,
+    default=default_release_prefix,
+)
+def create_release_branch(
+    release_type, pre_release, file, remote_name, branch_name, release_prefix
+):
     """
     Create a release branch and push it to the remote repository if the remote name is specified.
     """
@@ -99,6 +110,7 @@ def create_release_branch(release_type, pre_release, file, remote_name, branch_n
                 release_type,
                 remote_name,
                 branch_name,
+                release_prefix,
             )
         )
     )
@@ -150,8 +162,16 @@ def create_release_branch(release_type, pre_release, file, remote_name, branch_n
     default=default_version_file_type,
     required=False,
 )
+@click.option(
+    "--release-prefix",
+    "-P",
+    help="package/component prefix inserted into the release branch name and tag "
+    '(e.g. "habarico" -> release/habarico@v1.3 + tag habarico@1.3.0)',
+    type=str,
+    default=default_release_prefix,
+)
 def create_release(
-    release_type, pre_release, file, remote_name, branch_name, file_type
+    release_type, pre_release, file, remote_name, branch_name, file_type, release_prefix
 ):
     """
     Create a release branch and push it to the remote repository if the remote name is specified.
@@ -165,7 +185,13 @@ def create_release(
     click.echo(
         'New release branch "{}" was created'.format(
             create_release_func(
-                file, release_type, remote_name, branch_name, file_type, pre_release
+                file,
+                release_type,
+                remote_name,
+                branch_name,
+                file_type,
+                pre_release,
+                release_prefix,
             )
         )
     )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="developers-chamber",
-    version="0.1.48",
+    version="0.1.49",
     description="A small plugin which help with development, deployment, git",
     keywords="django, skripts, easy live, git, bitbucket, Jira",
     author="Druids team",


### PR DESCRIPTION
…-release commands

- Add optional `--release-prefix/-P` option (default from `RELEASE_PREFIX` env var) to `git create-release` and `git create-release-branch`
- When a prefix is set, join it to the version with `@`, producing branch names like `release/habarico@v1.3` and tags like `habarico@1.3.0`, so monorepos can release multiple packages without collisions
- Extract `_release_prefix_part`, `_release_branch_name` and `_release_tag_name` helpers in git_utils; use the tag name consistently for existence checks, tagging, deletion and pushing
- Make `VERSION_PATTERN` prefix-agnostic so a prefixed tag resolves back to the bare version
- Document the new option and `RELEASE_PREFIX` config in README
- Bump version 0.1.48 -> 0.1.49