### PR TITLE
AddedMissinProp: add release prefix support to commit-version

### DIFF
--- a/developers_chamber/git_utils.py
+++ b/developers_chamber/git_utils.py
@@ -200,9 +200,15 @@ def bump_version_from_release_tag(files=["version.json"]):
     return match.group("version")
 
 
-def commit_version(version, files=["version.json"], remote_name=None):
+def commit_version(
+    version, files=["version.json"], remote_name=None, release_prefix=None
+):
     repo = _repo()
     g = repo.git
+
+    # In a monorepo the tag must carry the release prefix (e.g. "habarico@1.3.0"),
+    # otherwise packages collide on the same bare "1.3.0" tag.
+    tag_name = _release_tag_name(version, release_prefix)
 
     try:
         # Add files by absolute path: g.add runs with cwd == git root, but the version
@@ -217,17 +223,17 @@ def commit_version(version, files=["version.json"], remote_name=None):
         )
 
     try:
-        g.tag(str(version))
+        g.tag(tag_name)
     except GitCommandError as ex:
         raise UsageError(
             "Tag {} already exists or another git error was raised: {}".format(
-                version, ex
+                tag_name, ex
             )
         )
 
     if remote_name:
         g.push(remote_name, str(repo.head.reference))
-        g.push(remote_name, str(version))
+        g.push(remote_name, tag_name)
 
 
 def merge_release_branch(to_branch_name=None, remote_name=None):

--- a/developers_chamber/scripts/git.py
+++ b/developers_chamber/scripts/git.py
@@ -271,7 +271,14 @@ def bump_version_from_release_tag(file):
     default=default_version_file_type,
     required=False,
 )
-def commit_version(file, remote_name, file_type):
+@click.option(
+    "--release-prefix",
+    "-P",
+    help="prefix joined to the version tag with '@' (e.g. 'habarico' -> 'habarico@1.3.0')",
+    type=str,
+    default=default_release_prefix,
+)
+def commit_version(file, remote_name, file_type, release_prefix):
     """
     Commit version files and add git tag to the commit.
     """
@@ -283,6 +290,7 @@ def commit_version(file, remote_name, file_type):
             for f in get_version_files(version_file, file_type)
         ],
         remote_name,
+        release_prefix,
     )
     click.echo("Version commit change was successfully created")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="developers-chamber",
-    version="0.1.49",
+    version="0.1.50",
     description="A small plugin which help with development, deployment, git",
     keywords="django, skripts, easy live, git, bitbucket, Jira",
     author="Druids team",


### PR DESCRIPTION
- Add optional release_prefix argument to git_utils.commit_version and build the tag via _release_tag_name so monorepo packages get a prefixed tag (e.g. "habarico@1.3.0") instead of colliding on a bare "1.3.0" tag; use the prefixed tag name for tagging and pushing
- Expose the prefix on the commit-version CLI command via a new --release-prefix/-P option (defaulting to default_release_prefix)
- Bump package version to 0.1.50