### PR TITLE
ImprovedCommitMessage: use prefixed tag name in version bump commit

### DIFF
--- a/developers_chamber/git_utils.py
+++ b/developers_chamber/git_utils.py
@@ -214,7 +214,9 @@ def commit_version(
         # Add files by absolute path: g.add runs with cwd == git root, but the version
         # files may live in a subdirectory (monorepo WORKDIR) from which pydev was invoked.
         g.add([os.path.abspath(f) for f in files])
-        g.commit(m=f"Bump version to '{version}'")
+        # Use the prefixed tag name so the merge bump commit reads
+        # "Bump version to 'lib-a@1.3.0'" in a monorepo; with no prefix it stays "1.3.0".
+        g.commit(m=f"Bump version to '{tag_name}'")
     except GitCommandError as ex:
         raise UsageError(
             "Version files was not changed or another git error was raised: {}".format(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="developers-chamber",
-    version="0.1.50",
+    version="0.1.51",
     description="A small plugin which help with development, deployment, git",
     keywords="django, skripts, easy live, git, bitbucket, Jira",
     author="Druids team",


### PR DESCRIPTION
- commit_version now builds the "Bump version to '...'" message from the prefixed tag_name instead of the bare version, so in a monorepo the bump commit reads e.g. "Bump version to 'lib-a@1.3.0'"; without a prefix it stays "Bump version to '1.3.0'"
- bump package version 0.1.50 -> 0.1.51 in setup.py