### PR TITLE
YamlAndJsonConfiguration: support YAML and JSON configuration files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Tests
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install the package
+      run: |
+        python -m pip install -U pip
+        python -m pip install '.[git,test]'
+    - name: Configure git
+      run: |
+        git config --global user.name 'Test'
+        git config --global user.email 'test@example.com'
+        git config --global init.defaultBranch master
+    - name: Run tests
+      run: python -m pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,25 @@
+# Python
+__pycache__/
+*.py[cod]
 *.egg-info
-*.pyc
+.eggs/
+
+# Packaging
+build/
+dist/
+
+# Environments
 ve
+venv/
+.venv/
+
+# Tests
+.coverage
+htmlcov/
+.pytest_cache/
+.tox/
+
+# Editors and OS
 .idea/
+.vscode/
+.DS_Store

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+developers-chamber = {extras = ["test", "git"], file = ".", editable = true}
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,473 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d7abc36184c0f5d4984dea418a1a0700c919fabf5c84c600f4d7e4a67f8d2352"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775",
+                "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2026.7.22"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380",
+                "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62",
+                "sha256:04ce310cb89c15df659582aee80a0603788732a5e017d5bd5c81158106ce249c",
+                "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226",
+                "sha256:0e94703ec9684807f20cfb5eed95c70f67f2a8f21ad620146d7b5a13677b93e5",
+                "sha256:0fa1aec2d32bcc03c8fa0f6f1712caad1adc38509f31142112e5c9daf5b9c833",
+                "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b",
+                "sha256:16d10d789dd9bcca1173c95af82c58433122564b7bc39385124be735a35cbe99",
+                "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501",
+                "sha256:1d22856ffbe153a602df38e4a5464f0b748a54002e0d69ac6d2ad0a197cc99ec",
+                "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698",
+                "sha256:231ddcbb35e2ff8973e1365db41fe0572662893b99a05deb183b68ad4c0c8bd4",
+                "sha256:253a4a220747e8b5faf57ec320c4f5efb0cef05f647420bf267143ec15dba10a",
+                "sha256:280081916dc341820640489a66e4696049401ef1cf6dd672f672e70ad915aca3",
+                "sha256:2a441ea71902098ffe78c5abe6c494f44160b4af614ed16c3d9a3b1d17fd8ee2",
+                "sha256:304b13570067b2547562e308af560b3963857b1fa90bd6afd978130130fe2d6a",
+                "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e",
+                "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4",
+                "sha256:375b83ed0aecfce76c16d198fbc21f3b11b337d68662bea0a995046682a11419",
+                "sha256:3c09a49d6cde137258beb3d551994a2927fd35ad5cf96aed573f61bbd67c5f84",
+                "sha256:3d92613ec25e43b05f042302531ec0f00b8445190e43325880cbd6ab7c2581da",
+                "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519",
+                "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe",
+                "sha256:432786d3561e69aeeae6c7e8648964ce0ad05736120135601f87ac26b9c83381",
+                "sha256:43b9e366a31fdd1c87d0eb08f579b4a82b723ea54338f040d6b4e518a026ea29",
+                "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614",
+                "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0",
+                "sha256:476743fe6dfe14a2da12e3ac79125dc84a3b2cf8094369a47a1529b0cd8549fe",
+                "sha256:4773092f8019072343a7447203308b176e10199920eb02d6195e81bbb3274c29",
+                "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0",
+                "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917",
+                "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9",
+                "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32",
+                "sha256:58150c9f9b9a552505912d182ccdf26f6396fb6094816ceebcbb20eecabaed94",
+                "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63",
+                "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd",
+                "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198",
+                "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde",
+                "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012",
+                "sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1",
+                "sha256:65a7ff3f705e57d392f7261b6d0550fe137c3019477431f1c355e0db0a7d3e15",
+                "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b",
+                "sha256:67830fc78e67501f47bb950471b2dcb9b35b140084429318e862895a8e89c993",
+                "sha256:68ce9f4d6b26d5ccbf7fd4459bf75f74a0a146677ebba80597df60cbdb20e6f4",
+                "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5",
+                "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8",
+                "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35",
+                "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642",
+                "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2",
+                "sha256:79580094b00d1789d1f93ea55bc43cb2f611910c72235b7657f3482ddcc1b22d",
+                "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9",
+                "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c",
+                "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33",
+                "sha256:871ff67ea1aad4dfd91736464934d56b32dac49f9fbe16cddba36198a7b3a0db",
+                "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf",
+                "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9",
+                "sha256:8c041122946b7ba21bb32c45b1aa57b1be35527690aeb3c5c234521085632eee",
+                "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84",
+                "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44",
+                "sha256:920079c3f7456fa213e0829ed2073aaa727fd39d889ead5b4f35d0de5460d04f",
+                "sha256:93d59d504b230e83c7a843251681959a0b6a9cd76f6e146ce1b8a80eb8739af9",
+                "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9",
+                "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177",
+                "sha256:9bb41182d93ea91f60b4bc8fbf4c820c69ef8a12ab2d917f3f1834f1acad07e8",
+                "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b",
+                "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39",
+                "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41",
+                "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0",
+                "sha256:aa99adc8f081b475a12843953db36831eaf83ec33eb46a90629ca6a5de45a616",
+                "sha256:ac351b3b8014eead140e77e9717e2992c6bbe30b63bc3422422eb84865412e3d",
+                "sha256:ad41ba96094304aa090f5a30cb6e4fb3b3f1c264c523394b4c39bbacc4dc92ba",
+                "sha256:b5314963fce9b0b12743891de876e724997864ee22aa496f903f426c7e2fa5b2",
+                "sha256:bcf74c1df76758a395bf0af608c04c82257523f55c9868b334f06270d0f2112b",
+                "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9",
+                "sha256:c0323c9daef75ef2e5083624b4585018a0c9d5e3b40f607eed81a311270b934b",
+                "sha256:c1225416b463483160e4af85d5fc3a9690ccb53fd4b1865a6437825f5ede3209",
+                "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48",
+                "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046",
+                "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632",
+                "sha256:cd6280cf040f233bd7d3407b743b4b4c74f70e8e1c4199cb112a62c941c0772a",
+                "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2",
+                "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1",
+                "sha256:ddf4af30b417d9fe16481e9b81c27ab2a7cde1ff7ba3e85653b02db7d145dc7b",
+                "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990",
+                "sha256:df7276909358e5635ae203673ab7e509ddd224225a8d6b0790bf13eb2bde1cc5",
+                "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b",
+                "sha256:e9701d0049d92c16703a42771b98d560b95248949f23f8cf7b4eddd201814fb9",
+                "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534",
+                "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81",
+                "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a",
+                "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d",
+                "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf",
+                "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.9"
+        },
+        "click": {
+            "hashes": [
+                "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6",
+                "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==8.4.2"
+        },
+        "click-completion": {
+            "hashes": [
+                "sha256:5bf816b81367e638a190b6e91b50779007d14301b3f9f3145d68e3cade7bce86"
+            ],
+            "version": "==0.5.2"
+        },
+        "coloredlogs": {
+            "hashes": [
+                "sha256:34fad2e342d5a559c31b6c889e8d14f97cb62c47d9a2ae7b5ed14ea10a79eff8",
+                "sha256:b869a2dda3fa88154b9dd850e27828d8755bfab5a838a1c97fbc850c6e377c36"
+            ],
+            "version": "==10.0"
+        },
+        "developers-chamber": {
+            "editable": true,
+            "extras": [
+                "git",
+                "test"
+            ],
+            "file": "."
+        },
+        "gitdb": {
+            "hashes": [
+                "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571",
+                "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.0.12"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33",
+                "sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.37"
+        },
+        "humanfriendly": {
+            "hashes": [
+                "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477",
+                "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==10.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2",
+                "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==3.18"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730",
+                "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.3.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d",
+                "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.6"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f",
+                "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a",
+                "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf",
+                "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19",
+                "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf",
+                "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c",
+                "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175",
+                "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219",
+                "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb",
+                "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6",
+                "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab",
+                "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26",
+                "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1",
+                "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce",
+                "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218",
+                "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634",
+                "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695",
+                "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad",
+                "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73",
+                "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c",
+                "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe",
+                "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa",
+                "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559",
+                "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa",
+                "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37",
+                "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758",
+                "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f",
+                "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8",
+                "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d",
+                "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c",
+                "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97",
+                "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a",
+                "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19",
+                "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9",
+                "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9",
+                "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc",
+                "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2",
+                "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4",
+                "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354",
+                "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50",
+                "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698",
+                "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9",
+                "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b",
+                "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc",
+                "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115",
+                "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e",
+                "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485",
+                "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f",
+                "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12",
+                "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025",
+                "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009",
+                "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d",
+                "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b",
+                "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a",
+                "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5",
+                "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f",
+                "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d",
+                "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1",
+                "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287",
+                "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6",
+                "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f",
+                "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581",
+                "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed",
+                "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b",
+                "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c",
+                "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026",
+                "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8",
+                "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676",
+                "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6",
+                "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e",
+                "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d",
+                "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d",
+                "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01",
+                "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7",
+                "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419",
+                "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795",
+                "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1",
+                "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5",
+                "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d",
+                "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42",
+                "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe",
+                "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda",
+                "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e",
+                "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737",
+                "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523",
+                "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591",
+                "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc",
+                "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a",
+                "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==3.0.3"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79",
+                "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==26.3"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313",
+                "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==9.1.1"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:8c10c99a1b25d9a68058a1ad6f90381a62ba68230ca93966882a4dbc3bc9c33d",
+                "sha256:c10863aee750ad720f4f43436565e4c1698798d763b63234fb5021b6c616e423"
+            ],
+            "version": "==0.14.0"
+        },
+        "python-hosts": {
+            "hashes": [
+                "sha256:92229d610f1cdd4802f2f26aff15a4ff4e42dfa169d4dbf926adf1ddcbb21e62",
+                "sha256:a2ddb8cdaa5993c8f79f0807a414cb7f47bb89ac6d5772534f2bdc01c8de59f4"
+            ],
+            "version": "==0.4.6"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c",
+                "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a",
+                "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3",
+                "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956",
+                "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6",
+                "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c",
+                "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65",
+                "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a",
+                "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0",
+                "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b",
+                "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1",
+                "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6",
+                "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7",
+                "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e",
+                "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007",
+                "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310",
+                "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4",
+                "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9",
+                "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295",
+                "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea",
+                "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0",
+                "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e",
+                "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac",
+                "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9",
+                "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7",
+                "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35",
+                "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb",
+                "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b",
+                "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69",
+                "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5",
+                "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b",
+                "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c",
+                "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369",
+                "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd",
+                "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824",
+                "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198",
+                "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065",
+                "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c",
+                "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c",
+                "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764",
+                "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196",
+                "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b",
+                "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00",
+                "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac",
+                "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8",
+                "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e",
+                "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28",
+                "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3",
+                "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5",
+                "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4",
+                "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b",
+                "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf",
+                "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5",
+                "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702",
+                "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8",
+                "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788",
+                "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da",
+                "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d",
+                "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc",
+                "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c",
+                "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba",
+                "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f",
+                "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917",
+                "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5",
+                "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26",
+                "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f",
+                "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b",
+                "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be",
+                "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c",
+                "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3",
+                "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6",
+                "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926",
+                "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0.3"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0",
+                "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.34.2"
+        },
+        "shellingham": {
+            "hashes": [
+                "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686",
+                "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.5.4"
+        },
+        "six": {
+            "hashes": [
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.17.0"
+        },
+        "smmap": {
+            "hashes": [
+                "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c",
+                "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==5.0.3"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==0.10.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,41 @@ Library of helpers for python development.
 pip install developers-chamber
 ```
 
+## Optional modules
+
+The commands which need a heavier library are shipped as extras and the command group appears only when its extra is installed:
+
+| extra | commands |
+| --- | --- |
+| `git` | `pydev git` |
+| `gitlab` | `pydev gitlab` |
+| `bitbucket` | `pydev bitbucket` |
+| `jira` | `pydev jira` |
+| `toggle` | `pydev toggle` |
+| `slack` | `pydev slack` |
+| `aws` | `pydev ecs` |
+| `qa` | `pydev qa` |
+
+```bash
+pip install 'developers-chamber[git,jira]'
+```
+
+# Development
+
+Install the library in the editable mode together with the extras you need and the test extra:
+
+```bash
+pip install -e '.[git,test]'
+```
+
+Run the tests with pytest from the root of the repository:
+
+```bash
+pytest
+```
+
+The tests of the `pydev git` commands are skipped without the `git` extra, the rest of the suite needs no extra at all.
+
 ## Required system libraries
 
 ### Docker
@@ -43,21 +78,28 @@ The purpose of the general pydev settings is to have some place where you can st
 The project configuration directory is stored in path `$PROJECT_DIR/.pydev` and works only if pydev commands are run in the `$PROJECT_DIR` directory. The same values in the general configuration will be overriden by to project configuration. 
 
 
-Configuration files which are stored in the `.pydev` directory must have this format:
+Configuration files which are stored in the `.pydev` directory can be written in three formats which are recognized by the file suffix:
+
+* `.conf` - the plain `KEY=VALUE` format
+* `.yaml` or `.yml`
+* `.json`
+
+The formats can be mixed in one directory and the files are applied in the alphabetical order of their whole name no matter the format:
+
 ```bash
 ./.pydev/
-    base.conf
+    base.yaml
     dev.conf
-    prod.conf
+    prod.json
 ```
 
-If you want to disable configuration file you can rename it to start with character `~`. In the example `~prod.conf` will be ignored:
+If you want to disable configuration file you can rename it to start with character `~`. In the example `~prod.yaml` will be ignored:
 
 ```bash
 ./.pydev/
-    base.conf
+    base.yaml
     dev.conf
-    ~prod.conf
+    ~prod.yaml
 ```
 
 The configuration file may contain project settings and aliases.
@@ -66,6 +108,7 @@ The configuration file may contain project settings and aliases.
 
 Project settings saves the time to the developers because pydev input parameters may be omitted if the parameter is defined in the configuration file. Example of such file can be:
 
+```bash
 JIRA_PROJECT_KEY=PROJ
 PROJECT_DOCKER_COMPOSE_FILES=path/to/the/compose.yaml
 PROJECT_DOCKER_COMPOSE_DEFAULT_UP_CONTAINERS=container_a,container_b
@@ -73,15 +116,52 @@ PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY=container_a:/usr/local/lib/python3
 PROJECT_DOCKER_COMPOSE_CONTAINERS_INSTALL_COMMAND=base:./manage.py compilemessages && ./manage.py migrate && ./manage.py collectstatic
 PROJECT_DOCKER_COMPOSE_VAR_DIRS=var,var/data/media,var/data/static
 PROJECT_LIBRARY_DIR=var/site-packages
+```
+
+The same settings written in the YAML format:
+
+```yaml
+jira:
+  project_key: PROJ
+
+project:
+  library_dir: var/site-packages
+  docker_compose:
+    files: [path/to/the/compose.yaml]
+    default_up_containers: [container_a, container_b]
+    var_dirs: [var, var/data/media, var/data/static]
+    containers_dir_to_copy:
+      container_a:
+        /usr/local/lib/python3.11/site-packages: var/site-packages
+    containers_install_command:
+      base: ./manage.py compilemessages && ./manage.py migrate && ./manage.py collectstatic
+```
+
+The structured formats are translated into the same settings which the commands read, therefore the rules are:
+
+* A nested object is a section and its name is joined to the name of its keys with an underscore, so `jira.project_key` becomes `JIRA_PROJECT_KEY`. Dashes in the names are read as underscores.
+* A list is joined with a comma, so `files: [a.yaml, b.yaml]` becomes `a.yaml,b.yaml`.
+* A `null` value is ignored, which is useful for turning a setting of the general configuration off.
+* Settings which have their own format - `aliases`, `containers_dir_to_copy`, `containers_install_command` and `containers_env` - accept the structured notation shown above. Each of them accepts the plain string notation too, so you can always fall back to it.
+
+A setting which is defined in a configuration file overrides the environment variable of the same name.
 
 ### Alias
 
-Alias is a shortcut for the developer to save his time and are defined with `ALIASES` setting in a JSON format:
+Alias is a shortcut for the developer to save his time and are defined with the `aliases` setting:
+
+```yaml
+aliases:
+  up: project up
+  up-all: project up -a
+```
+
+In the `.conf` format the same aliases have to be written as a JSON string:
 
 ```bash
 ALIASES='{
     "up": "project up",
-    "up-all": "project up -a",
+    "up-all": "project up -a"
 }'
 ```
 
@@ -94,10 +174,9 @@ pydev up-all # instead of pydev project up -a
 
 You can write alias with arguments too:
 
-```bash
-ALIASES='{
-    "migrate": "project run \"python manage.py migrate $app\"",
-}'
+```yaml
+aliases:
+  migrate: project run "python manage.py migrate $app"
 ```
 
 You can now run migration to the concrete app with:
@@ -106,12 +185,13 @@ You can now run migration to the concrete app with:
 pydev migrate --app=users # it will run pydev project run "python manage.py migrate users"
 ```
 
-There can be situations when you need to alias on more commands. You can use JSON list to specify it:
+There can be situations when you need to alias on more commands. You can use a list to specify it:
 
-```bash
-ALIASES='{
-    "build-js": ["project run -c static \"build-js.sh\"", "project run -c base \"./manage.py collectstatic\""],
-}'
+```yaml
+aliases:
+  build-js:
+    - project run -c static "build-js.sh"
+    - project run -c base "./manage.py collectstatic"
 ```
 
 Now you can run only one pydev command to build js and collect django static files:
@@ -120,14 +200,32 @@ Now you can run only one pydev command to build js and collect django static fil
 pydev buildjs
 ```
 
-Everything what you define after pydev alias will be sent into the command:
+An alias can describe itself. Instead of the command write an object with the `description` and the `command` key, where the command is again either a single command or a list of them:
+
+```yaml
+aliases:
+  build-js:
+    description: Build js and collect django static files
+    command:
+      - project run -c static "build-js.sh"
+      - project run -c base "./manage.py collectstatic"
+```
+
+The description is then shown next to the alias in `pydev --help` and above the list of the aliased commands in `pydev build-js --help`:
 
 ```bash
-ALIASES='{
-    "run-dj": "project run \"./manage.py\"",
-}'
+Aliases:
+  build-js  Build js and collect django static files
+```
 
-# bash
+Everything what you define after pydev alias will be sent into the command:
+
+```yaml
+aliases:
+  run-dj: project run "./manage.py"
+```
+
+```bash
 pydev run-dj migrate --no-input
 ```
 

--- a/developers_chamber/bin/pydev.py
+++ b/developers_chamber/bin/pydev.py
@@ -7,18 +7,14 @@ from importlib.machinery import SourceFileLoader
 
 import click_completion
 import coloredlogs
-from dotenv import load_dotenv
+from developers_chamber.config import ConfigError, load_config
 from developers_chamber.utils import INSTALLED_MODULES
 
-for config_path in (Path.home(), Path.cwd()):
-    if (config_path / ".pydev").exists() and (config_path / ".pydev").is_dir():
-        for file in sorted((config_path / ".pydev").iterdir()):
-            if (
-                file.is_file()
-                and file.suffix == ".conf"
-                and not file.name.startswith("~")
-            ):
-                load_dotenv(dotenv_path=str(file), override=True)
+try:
+    load_config()
+except ConfigError as ex:
+    sys.stderr.write("{}\n".format(ex))
+    sys.exit(1)
 
 
 from developers_chamber.scripts import cli

--- a/developers_chamber/click/options.py
+++ b/developers_chamber/click/options.py
@@ -29,58 +29,150 @@ class RequiredIfNotEmpty(click.Option):
         return super().handle_parse_result(ctx, opts, args)
 
 
-class ContainerDirToCopyType(click.ParamType):
+class CommaSeparatedType(click.types.StringParamType):
+    """
+    Plain string option whose environment variable holds a comma separated list.
 
-    name = "container_dir_to_copy"
+    Click splits the value of the environment variable by ``envvar_list_splitter`` before it
+    converts the items, so a repeatable option accepts both several occurrences on the command
+    line and one comma separated environment variable.
+    """
+
+    name = "text"
+    envvar_list_splitter = ","
+
+
+class CommaSeparatedPathType(click.Path):
+    """Path option whose environment variable holds a comma separated list."""
+
+    envvar_list_splitter = ","
+
+
+COMMA_SEPARATED = CommaSeparatedType()
+
+
+class SeparatedFieldsType(click.ParamType):
+    """
+    Base class of the types whose value is a fixed number of fields joined with a separator.
+
+    The separator and the field names are declared once and both directions are derived from
+    them, therefore the parsing in ``convert`` and the encoding of the configuration files in
+    ``encode`` cannot drift apart.
+    """
+
+    separator = ":"
+    fields = ()
+    envvar_list_splitter = ","
+
+    @property
+    def format_hint(self):
+        return self.separator.join(self.fields)
 
     def convert(self, value, param, ctx):
-        try:
-            container_name, container_dir, host_dir = value.split(":")
-            return container_name, container_dir, host_dir
-        except ValueError:
+        parts = value.split(self.separator)
+        if len(parts) != len(self.fields):
             self.fail(
-                'Invalid value "{}" format must be "DOCKER_CONTAINER_NAME:CONTAINER_DIRECTORY:HOST_DIRECTORY"'.format(
-                    value
+                'Invalid value "{}" format must be "{}"'.format(
+                    value, self.format_hint
                 ),
                 param,
                 ctx,
             )
+        return tuple(parts)
 
 
-class ContainerCommandType(click.ParamType):
+def encode_field(value, name):
+    """Turn a single field of a structured configuration value into its string form."""
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise ValueError('"{}" must be a string'.format(name))
+    return str(value)
+
+
+class ContainerDirToCopyType(SeparatedFieldsType):
+
+    name = "container_dir_to_copy"
+    fields = ("DOCKER_CONTAINER_NAME", "CONTAINER_DIRECTORY", "HOST_DIRECTORY")
+
+    @classmethod
+    def encode(cls, value):
+        """Encode {container: {container directory: host directory}} into the value items."""
+        if isinstance(value, (str, list, tuple)):
+            return value
+        if not isinstance(value, dict):
+            raise ValueError(
+                "must be an object of container name to an object of container directory "
+                "to host directory"
+            )
+        items = []
+        for container_name, dirs in value.items():
+            if not isinstance(dirs, dict):
+                raise ValueError(
+                    'container "{}" must be an object of container directory to host '
+                    "directory".format(container_name)
+                )
+            items.extend(
+                cls.separator.join(
+                    (
+                        str(container_name),
+                        str(container_dir),
+                        encode_field(host_dir, container_dir),
+                    )
+                )
+                for container_dir, host_dir in dirs.items()
+            )
+        return items
+
+
+class ContainerCommandType(SeparatedFieldsType):
 
     name = "container_command_type"
+    fields = ("DOCKER_CONTAINER_NAME", "COMMAND")
 
-    def convert(self, value, param, ctx):
-        if value:
-            try:
-                container_name, command = value.split(":")
-                return container_name, command
-            except ValueError:
-                self.fail(
-                    'Invalid value "{}" format must be "DOCKER_CONTAINER_NAME:COMMAND"'.format(
-                        value
-                    ),
-                    param,
-                    ctx,
-                )
+    @classmethod
+    def encode(cls, value):
+        """Encode {container: command} into the value items."""
+        if isinstance(value, (str, list, tuple)):
+            return value
+        if not isinstance(value, dict):
+            raise ValueError("must be an object of container name to command")
+        return [
+            cls.separator.join(
+                (str(container_name), encode_field(command, container_name))
+            )
+            for container_name, command in value.items()
+        ]
 
 
 class ContainerEnvironment(click.ParamType):
 
     name = "container_environment"
+    separator = " "
+    assignment = "="
+    format_hint = "NAME=VALUE [NAME2=VALUE2]"
 
     def convert(self, value, param, ctx):
-        try:
-            return {
-                variable.split("=")[0]: variable.split("=")[1]
-                for variable in value.split(" ")
-            }
-        except ValueError:
-            self.fail(
-                'Invalid value "{}" format must be "NAME=VALUE [NAME2=VALUE2]"'.format(
-                    value
-                ),
-                param,
-                ctx,
-            )
+        variables = {}
+        for variable in value.split(self.separator):
+            name, assignment, item = variable.partition(self.assignment)
+            if not assignment:
+                self.fail(
+                    'Invalid value "{}" format must be "{}"'.format(
+                        value, self.format_hint
+                    ),
+                    param,
+                    ctx,
+                )
+            variables[name] = item
+        return variables
+
+    @classmethod
+    def encode(cls, value):
+        """Encode {variable name: value} into the whole value of the setting."""
+        if isinstance(value, str):
+            return value
+        if not isinstance(value, dict):
+            raise ValueError("must be an object of variable name to value")
+        return cls.separator.join(
+            cls.assignment.join((str(name), encode_field(item, name)))
+            for name, item in value.items()
+        )

--- a/developers_chamber/config.py
+++ b/developers_chamber/config.py
@@ -1,0 +1,175 @@
+import json
+import os
+from pathlib import Path
+
+import yaml
+from dotenv import load_dotenv
+
+from developers_chamber.click.options import (
+    ContainerCommandType,
+    ContainerDirToCopyType,
+    ContainerEnvironment,
+)
+
+CONFIG_DIR_NAME = ".pydev"
+DOTENV_SUFFIXES = (".conf",)
+JSON_SUFFIXES = (".json",)
+YAML_SUFFIXES = (".yaml", ".yml")
+STRUCTURED_SUFFIXES = JSON_SUFFIXES + YAML_SUFFIXES
+
+
+class ConfigError(Exception):
+    """Raised when a configuration file cannot be read or has an invalid structure."""
+
+
+def _format_path(path):
+    return ".".join(path) if path else "<root>"
+
+
+def _fail(path, message):
+    raise ConfigError('setting "{}": {}'.format(_format_path(path), message))
+
+
+def _encode_scalar(value, path):
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    _fail(path, "unsupported value type {}".format(type(value).__name__))
+
+
+def _encode_value(value, path):
+    """Encode a value which has no dedicated encoder into its environment variable form."""
+    if isinstance(value, (list, tuple)):
+        return ",".join(_encode_scalar(item, path) for item in value)
+    return _encode_scalar(value, path)
+
+
+def _encode_aliases(value, path):
+    """
+    ALIASES is read with ``json.loads`` in ``developers_chamber.scripts.init_aliasses``.
+
+    Only the shape of the whole setting is checked here, the accepted form of a single alias
+    is validated by ``AliasCommand`` which is the one that knows it.
+    """
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, dict):
+        _fail(path, "must be an object of alias name to command")
+    return json.dumps(value)
+
+
+def _param_type_encoder(param_type):
+    """
+    Build an encoder delegating to the param type which parses the setting back.
+
+    The param type returns either the whole value of the setting or its items which are then
+    joined by the common list separator.
+    """
+
+    def encode(value, path):
+        try:
+            return _encode_value(param_type.encode(value), path)
+        except ValueError as ex:
+            _fail(path, str(ex))
+
+    return encode
+
+
+# Settings which are not plain scalars or comma separated lists. The key is the resulting
+# environment variable name, the value is a callable turning the structured value into the
+# string form expected by the command which reads it. Every encoder also accepts the string
+# form itself, so the flat notation keeps working in the structured config files too.
+SETTING_ENCODERS = {
+    "ALIASES": _encode_aliases,
+    "PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY": _param_type_encoder(
+        ContainerDirToCopyType
+    ),
+    "PROJECT_DOCKER_COMPOSE_CONTAINERS_INSTALL_COMMAND": _param_type_encoder(
+        ContainerCommandType
+    ),
+    "PROJECT_DOCKER_COMPOSE_CONTAINERS_ENV": _param_type_encoder(ContainerEnvironment),
+}
+
+
+def _flatten(data, name_parts, path, result):
+    for key, value in data.items():
+        name_parts_of_key = name_parts + (str(key).replace("-", "_").upper(),)
+        name = "_".join(name_parts_of_key)
+        key_path = path + (str(key),)
+
+        if value is None:
+            continue
+
+        encoder = SETTING_ENCODERS.get(name)
+        if encoder is not None:
+            result[name] = encoder(value, key_path)
+        elif isinstance(value, dict):
+            _flatten(value, name_parts_of_key, key_path, result)
+        else:
+            result[name] = _encode_value(value, key_path)
+    return result
+
+
+def flatten_settings(data):
+    """
+    Turn a structured configuration into the environment variables which the pydev commands read.
+
+    Nested objects are sections joined with an underscore (``jira.project_key`` becomes
+    ``JIRA_PROJECT_KEY``), lists are joined with a comma and ``None`` values are left out.
+    Settings listed in ``SETTING_ENCODERS`` are encoded by their own rules.
+    """
+    if not isinstance(data, dict):
+        _fail((), "root element must be an object")
+    return _flatten(data, (), (), {})
+
+
+def load_settings_file(file):
+    """Read a single JSON or YAML configuration file and return its environment variables."""
+    file = Path(file)
+    try:
+        with file.open() as f:
+            if file.suffix in JSON_SUFFIXES:
+                data = json.load(f)
+            else:
+                data = yaml.safe_load(f)
+    except (json.JSONDecodeError, yaml.YAMLError) as ex:
+        raise ConfigError('Invalid config file "{}": {}'.format(file, ex))
+
+    if data is None:
+        return {}
+
+    try:
+        return flatten_settings(data)
+    except ConfigError as ex:
+        raise ConfigError('Invalid config file "{}": {}'.format(file, ex))
+
+
+def iter_config_files(config_dir):
+    """Yield enabled configuration files of the directory in the order in which they are applied."""
+    if not config_dir.is_dir():
+        return
+    for file in sorted(config_dir.iterdir()):
+        if not file.is_file() or file.name.startswith("~"):
+            continue
+        if file.suffix in DOTENV_SUFFIXES + STRUCTURED_SUFFIXES:
+            yield file
+
+
+def load_config(config_paths=None):
+    """
+    Load the pydev configuration into the environment variables.
+
+    The general configuration in the home directory is loaded first and the project one in the
+    current directory second, therefore the project configuration wins. Inside a directory the
+    files are applied in the alphabetical order no matter their format.
+    """
+    if config_paths is None:
+        config_paths = (Path.home(), Path.cwd())
+
+    for config_path in config_paths:
+        for file in iter_config_files(Path(config_path) / CONFIG_DIR_NAME):
+            if file.suffix in DOTENV_SUFFIXES:
+                load_dotenv(dotenv_path=str(file), override=True)
+            else:
+                os.environ.update(load_settings_file(file))

--- a/developers_chamber/git_utils.py
+++ b/developers_chamber/git_utils.py
@@ -8,7 +8,11 @@ from git import GitCommandError, InvalidGitRepositoryError
 from .types import ReleaseType, VersionFileType
 from .version_utils import bump_to_next_version, bump_version, get_version
 
-DEPLOYMENT_COMMIT_PATTERN = r'^Deployment of "(?P<branch_name>.+)"$'
+# Both quote styles are accepted: create_deployment_branch writes the branch name in single
+# quotes, older deployment branches may still carry the double quoted form.
+DEPLOYMENT_COMMIT_PATTERN = (
+    r"^Deployment of (?P<quote>[\"'])(?P<branch_name>.+)(?P=quote)$"
+)
 # The optional "<prefix>@" (or "<prefix>/") group lets a package-prefixed tag like
 # "habarico@1.3.0" resolve back to the bare version. Prefix-agnostic on purpose.
 VERSION_PATTERN = r"^(?:.+[@/])?(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$"
@@ -275,7 +279,7 @@ def get_commit_hash(branch_name):
 
 def get_current_issue_key():
     branch_name = get_current_branch_name()
-    match = re.match("(?P<issue_key>.{3}-\d+).*", branch_name)
+    match = re.match(r"(?P<issue_key>.{3}-\d+).*", branch_name)
     if match:
         return match.group("issue_key")
     else:

--- a/developers_chamber/scripts/bitbucket.py
+++ b/developers_chamber/scripts/bitbucket.py
@@ -1,4 +1,3 @@
-import os
 
 import click
 
@@ -8,10 +7,7 @@ from developers_chamber.bitbucket_utils import (
 from developers_chamber.git_utils import get_current_branch_name
 from developers_chamber.scripts import cli
 
-default_username = os.environ.get("BITBUCKET_USERNAME")
-default_password = os.environ.get("BITBUCKET_PASSWORD")
-default_destination_branch_name = os.environ.get("BITBUCKET_BRANCH_NAME", "next")
-default_repository_name = os.environ.get("BITBUCKET_REPOSITORY")
+
 
 
 @cli.group()
@@ -26,7 +22,7 @@ def bitbucket():
     help="username",
     type=str,
     required=True,
-    default=default_username,
+    envvar="BITBUCKET_USERNAME",
 )
 @click.option(
     "--password",
@@ -34,7 +30,7 @@ def bitbucket():
     help="password",
     type=str,
     required=True,
-    default=default_password,
+    envvar="BITBUCKET_PASSWORD",
 )
 @click.option("--source-branch-name", "-s", help="source git branch name", type=str)
 @click.option(
@@ -43,7 +39,8 @@ def bitbucket():
     help="destination git branch name",
     type=str,
     required=True,
-    default=default_destination_branch_name,
+    envvar="BITBUCKET_BRANCH_NAME",
+    default="next",
 )
 @click.option(
     "--repository-name",
@@ -51,7 +48,7 @@ def bitbucket():
     help="git repository name",
     type=str,
     required=True,
-    default=default_repository_name,
+    envvar="BITBUCKET_REPOSITORY",
 )
 def create_release_pull_request(
     username, password, source_branch_name, destination_branch_name, repository_name

--- a/developers_chamber/scripts/ecs.py
+++ b/developers_chamber/scripts/ecs.py
@@ -1,4 +1,3 @@
-import os
 
 import click
 
@@ -44,8 +43,6 @@ from developers_chamber.ecs_utils import (
 )
 from developers_chamber.scripts import cli
 
-default_region = os.environ.get("AWS_REGION")
-default_cluster = os.environ.get("AWS_ECS_CLUSTER")
 
 
 @cli.group()
@@ -59,7 +56,7 @@ def ecs():
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service names", type=str, required=True)
@@ -74,7 +71,7 @@ def ecs():
     required=True,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def deploy_new_task_definition(cluster, service, task_definition, images, region):
     """
@@ -95,7 +92,7 @@ def deploy_new_task_definition(cluster, service, task_definition, images, region
     required=True,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def register_new_task_definition(task_definition, images, region):
     """
@@ -110,12 +107,12 @@ def register_new_task_definition(task_definition, images, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service names", type=str, required=True)
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def update_service_to_latest_task_definition(cluster, service, region):
     """
@@ -130,12 +127,12 @@ def update_service_to_latest_task_definition(cluster, service, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service name", type=str, required=True)
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def stop_service(cluster, service, region):
     """
@@ -150,13 +147,13 @@ def stop_service(cluster, service, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service name", type=str, required=True)
 @click.option("--count", "-o", help="Desired count for service", type=int)
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def start_service(cluster, service, count, region):
     """
@@ -171,12 +168,12 @@ def start_service(cluster, service, count, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--count", "-o", help="Desired count for service", type=int)
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def start_cluster_services(cluster, count, region):
     """
@@ -191,7 +188,7 @@ def start_cluster_services(cluster, count, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option(
@@ -203,7 +200,7 @@ def start_cluster_services(cluster, count, region):
 )
 @click.option("--count", "-o", help="Desired count for service", type=int)
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def start_services(cluster, services, count, region):
     """
@@ -219,7 +216,7 @@ def start_services(cluster, services, count, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option(
@@ -228,7 +225,7 @@ def start_services(cluster, services, count, region):
 @click.option("--command", "-m", help="command to run", type=str, default=None)
 @click.option("--name", "-n", help="ECS task name", type=str, required=True)
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def run_task(cluster, task_definition, command, name, region):
     """
@@ -243,7 +240,7 @@ def run_task(cluster, task_definition, command, name, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option(
@@ -266,7 +263,7 @@ def run_task(cluster, task_definition, command, name, region):
     default=600,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def run_task_and_wait_for_success(
     cluster, task_definition, command, name, success_string, timeout, region
@@ -285,7 +282,7 @@ def run_task_and_wait_for_success(
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service name", type=str, required=True)
@@ -312,7 +309,7 @@ def run_task_and_wait_for_success(
     default=None,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def run_service_task(
     cluster, service, command, success_string, timeout, region, container
@@ -331,7 +328,7 @@ def run_service_task(
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service name", type=str, required=True)
@@ -358,7 +355,7 @@ def run_service_task(
     default=None,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 @click.option("--subnet", help="subnet ID", type=str, required=True, multiple=True)
 @click.option(
@@ -413,12 +410,12 @@ def run_service_task_fargate(
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service name", type=str, required=True)
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def get_tasks_for_service(cluster, service, region):
     """
@@ -433,12 +430,12 @@ def get_tasks_for_service(cluster, service, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service name", type=str, required=True)
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def get_task_definition_for_service(cluster, service, region):
     """
@@ -453,7 +450,7 @@ def get_task_definition_for_service(cluster, service, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option("--service", "-s", help="ECS service name", type=str, required=True)
@@ -465,7 +462,7 @@ def get_task_definition_for_service(cluster, service, region):
     default=600,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def stop_service_and_wait_for_tasks_to_stop(cluster, service, timeout, region):
     """
@@ -480,7 +477,7 @@ def stop_service_and_wait_for_tasks_to_stop(cluster, service, timeout, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option(
@@ -498,7 +495,7 @@ def stop_service_and_wait_for_tasks_to_stop(cluster, service, timeout, region):
     default=600,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def stop_services_and_wait_for_tasks_to_stop(cluster, services, timeout, region):
     """
@@ -514,11 +511,11 @@ def stop_services_and_wait_for_tasks_to_stop(cluster, services, timeout, region)
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def get_services_names(cluster, region):
     """
@@ -534,7 +531,7 @@ def get_services_names(cluster, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option(
@@ -545,7 +542,7 @@ def get_services_names(cluster, region):
     required=True,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def redeploy_services(cluster, services, region):
     """
@@ -561,11 +558,11 @@ def redeploy_services(cluster, services, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def redeploy_cluster_services(cluster, region):
     """
@@ -580,11 +577,11 @@ def redeploy_cluster_services(cluster, region):
     "-c",
     help="ECS cluster name",
     type=str,
-    default=default_cluster,
+    envvar="AWS_ECS_CLUSTER",
     required=True,
 )
 @click.option(
-    "--region", "-r", help="AWS region", type=str, default=default_region, required=True
+    "--region", "-r", help="AWS region", type=str, envvar="AWS_REGION", required=True
 )
 def wait_for_services_stable(cluster, region):
     """

--- a/developers_chamber/scripts/git.py
+++ b/developers_chamber/scripts/git.py
@@ -21,6 +21,7 @@ from developers_chamber.git_utils import (
 from developers_chamber.git_utils import (
     merge_release_branch as merge_release_branch_func,
 )
+from developers_chamber.click.options import CommaSeparatedPathType
 from developers_chamber.scripts import cli
 from developers_chamber.types import (
     EnumType,
@@ -34,11 +35,8 @@ from developers_chamber.version_utils import (
     get_version_files,
 )
 
-from .version import default_version_files, default_version_file_type
+from .version import _default_version_file
 
-default_remote_name = os.environ.get("GIT_REMOTE_NAME")
-default_branch_name = os.environ.get("GIT_BRANCH_NAME")
-default_release_prefix = os.environ.get("RELEASE_PREFIX")
 
 
 @cli.group()
@@ -67,7 +65,7 @@ def git():
     "--file",
     "-f",
     help="path to the version file",
-    default=default_version_files[0],
+    default=_default_version_file,
     required=True,
     type=click.Path(exists=True),
 )
@@ -76,14 +74,14 @@ def git():
     "-r",
     help="remote repository name if you want to push the new branch",
     type=str,
-    default=default_remote_name,
+    envvar="GIT_REMOTE_NAME",
 )
 @click.option(
     "--branch-name",
     "-b",
     help="branch name if you want to create branch from another repository",
     type=str,
-    default=default_branch_name,
+    envvar="GIT_BRANCH_NAME",
 )
 @click.option(
     "--release-prefix",
@@ -91,7 +89,7 @@ def git():
     help="package/component prefix inserted into the release branch name "
     '(e.g. "habarico" -> release/habarico@v1.3)',
     type=str,
-    default=default_release_prefix,
+    envvar="RELEASE_PREFIX",
 )
 def create_release_branch(
     release_type, pre_release, file, remote_name, branch_name, release_prefix
@@ -137,7 +135,7 @@ def create_release_branch(
     "--file",
     "-f",
     help="path to the version file",
-    default=default_version_files[0],
+    default=_default_version_file,
     required=True,
     type=click.Path(exists=True),
 )
@@ -146,20 +144,20 @@ def create_release_branch(
     "-r",
     help="remote repository name if you want to push the new branch",
     type=str,
-    default=default_remote_name,
+    envvar="GIT_REMOTE_NAME",
 )
 @click.option(
     "--branch-name",
     "-b",
     help="branch name if you want to create branch from another repository",
     type=str,
-    default=default_branch_name,
+    envvar="GIT_BRANCH_NAME",
 )
 @click.option(
     "--file-type",
     help="version file type",
     type=EnumType(VersionFileType),
-    default=default_version_file_type,
+    envvar="VERSION_FILE_TYPE",
     required=False,
 )
 @click.option(
@@ -168,7 +166,7 @@ def create_release_branch(
     help="package/component prefix inserted into the release branch name and tag "
     '(e.g. "habarico" -> release/habarico@v1.3 + tag habarico@1.3.0)',
     type=str,
-    default=default_release_prefix,
+    envvar="RELEASE_PREFIX",
 )
 def create_release(
     release_type, pre_release, file, remote_name, branch_name, file_type, release_prefix
@@ -206,7 +204,7 @@ def create_release(
     "-r",
     help="remote repository name if you want to push the new branch",
     type=str,
-    default=default_remote_name,
+    envvar="GIT_REMOTE_NAME",
 )
 @click.option("--hot", "-h", help="hot deployment", is_flag=True, default=False)
 def create_deployment_branch(environment, remote_name, hot):
@@ -233,10 +231,11 @@ def checkout_to_release_branch():
     "--file",
     "-f",
     help="path to the version file",
-    default=default_version_files,
+    envvar="VERSION_FILES",
+    default=("version.json",),
     required=True,
     multiple=True,
-    type=click.Path(exists=True),
+    type=CommaSeparatedPathType(exists=True),
 )
 def bump_version_from_release_tag(file):
     """
@@ -252,23 +251,24 @@ def bump_version_from_release_tag(file):
     "--file",
     "-f",
     help="path to the version file",
-    default=default_version_files,
+    envvar="VERSION_FILES",
+    default=("version.json",),
     required=True,
     multiple=True,
-    type=click.Path(exists=True),
+    type=CommaSeparatedPathType(exists=True),
 )
 @click.option(
     "--remote-name",
     "-r",
     help="remote repository name if you want to push the new branch",
     type=str,
-    default=default_remote_name,
+    envvar="GIT_REMOTE_NAME",
 )
 @click.option(
     "--file-type",
     help="version file type",
     type=EnumType(VersionFileType),
-    default=default_version_file_type,
+    envvar="VERSION_FILE_TYPE",
     required=False,
 )
 @click.option(
@@ -276,7 +276,7 @@ def bump_version_from_release_tag(file):
     "-P",
     help="prefix joined to the version tag with '@' (e.g. 'habarico' -> 'habarico@1.3.0')",
     type=str,
-    default=default_release_prefix,
+    envvar="RELEASE_PREFIX",
 )
 def commit_version(file, remote_name, file_type, release_prefix):
     """
@@ -302,7 +302,7 @@ def commit_version(file, remote_name, file_type, release_prefix):
     "-r",
     help="remote repository name if you want to push the new branch",
     type=str,
-    default=default_remote_name,
+    envvar="GIT_REMOTE_NAME",
 )
 def merge_release_branch(to_branch_name, remote_name):
     """

--- a/developers_chamber/scripts/gitlab.py
+++ b/developers_chamber/scripts/gitlab.py
@@ -11,13 +11,10 @@ from developers_chamber.gitlab_utils import (
 from developers_chamber.scripts import cli
 from developers_chamber.git_utils import get_remote_url, get_remote_path
 
-DEFAULT_API_URL = os.environ.get("GITLAB_API_URL")
-DEFAULT_URL = os.environ.get(
-    "GITLAB_URL", DEFAULT_API_URL and DEFAULT_API_URL.split("/api/v4")[0]
-)
-DEFAULT_PROJECT = os.environ.get("GITLAB_PROJECT")
-DEFAULT_TARGET_BRANCH = os.environ.get("GITLAB_TARGET_BRANCH", "next")
-DEFAULT_TOKEN = os.environ.get("GITLAB_TOKEN")
+def _default_gitlab_url():
+    """Without its own setting the web url is the api url without the /api/v4 suffix."""
+    api_url = os.environ.get("GITLAB_API_URL")
+    return api_url and api_url.split("/api/v4")[0]
 
 
 @cli.group()
@@ -31,35 +28,37 @@ def gitlab():
     help="GitLab instance API URL (defaults to gitlab.com)",
     type=str,
     required=False,
-    default=DEFAULT_URL,
+    envvar="GITLAB_URL",
+    default=_default_gitlab_url,
 )
 @click.option(
     "--token",
     help="token (can be set as env variable GITLAB_TOKEN)",
     type=str,
     required=True,
-    default=DEFAULT_TOKEN,
+    envvar="GITLAB_TOKEN",
 )
 @click.option("--source-branch", help="source Git branch", type=str)
 @click.option(
     "--target-branch",
     help="target Git branch (defaults to env variable GITLAB_TARGET_BRANCH)",
     type=str,
-    default=DEFAULT_TARGET_BRANCH,
+    envvar="GITLAB_TARGET_BRANCH",
+    default="next",
 )
 @click.option(
     "--project",
     help="GitLab project name (defaults to env variable GITLAB_PROJECT)",
     type=str,
     required=False,
-    default=DEFAULT_PROJECT,
+    envvar="GITLAB_PROJECT",
 )
 @click.option(
     "--assignee-id",
     help="User ID to assign the merge request",
     type=str,
     required=False,
-    default=DEFAULT_PROJECT,
+    envvar="GITLAB_PROJECT",
 )
 def create_release_merge_request(
     url, token, source_branch, target_branch, project, assignee_id=None
@@ -96,34 +95,37 @@ def create_release_merge_request(
     help="GitLab instance API URL (defaults to gitlab.com)",
     type=str,
     required=False,
-    default=DEFAULT_URL,
+    envvar="GITLAB_URL",
+    default=_default_gitlab_url,
 )
 @click.option(
     "--token",
     help="token (can be set as env variable GITLAB_TOKEN)",
     type=str,
     required=True,
-    default=DEFAULT_TOKEN,
+    envvar="GITLAB_TOKEN",
 )
 @click.option("--source-branch", help="source Git branch", type=str)
 @click.option(
     "--target-branch",
     help="Target Git branch (defaults to env variable GITLAB_TARGET_BRANCH)",
     type=str,
-    default=DEFAULT_TARGET_BRANCH,
+    envvar="GITLAB_TARGET_BRANCH",
+    default="next",
 )
 @click.option(
     "--title",
     help="Merge request title",
     type=str,
-    default=DEFAULT_TARGET_BRANCH,
+    envvar="GITLAB_TARGET_BRANCH",
+    default="next",
 )
 @click.option(
     "--project",
     help="GitLab project name (defaults to env variable GITLAB_PROJECT)",
     type=str,
     required=False,
-    default=DEFAULT_PROJECT,
+    envvar="GITLAB_PROJECT",
 )
 @click.option(
     "--automerge",
@@ -136,7 +138,7 @@ def create_release_merge_request(
     help="User ID to assign the merge request",
     type=str,
     required=False,
-    default=DEFAULT_PROJECT,
+    envvar="GITLAB_PROJECT",
 )
 @click.option(
     "--remove-source-branch",
@@ -185,21 +187,22 @@ def create_merge_request(
     help="GitLab instance API URL (defaults to gitlab.com)",
     type=str,
     required=False,
-    default=DEFAULT_URL,
+    envvar="GITLAB_URL",
+    default=_default_gitlab_url,
 )
 @click.option(
     "--token",
     help="token (can be set as env variable GITLAB_TOKEN)",
     type=str,
     required=True,
-    default=DEFAULT_TOKEN,
+    envvar="GITLAB_TOKEN",
 )
 @click.option(
     "--project",
     help="GitLab project name (defaults to env variable GITLAB_PROJECT)",
     type=str,
     required=False,
-    default=DEFAULT_PROJECT,
+    envvar="GITLAB_PROJECT",
 )
 @click.option(
     "--merge-request-id",
@@ -229,21 +232,22 @@ def activate_merge_request_automerge(url, token, project, merge_request_id):
     help="GitLab instance API URL (defaults to gitlab.com)",
     type=str,
     required=False,
-    default=DEFAULT_URL,
+    envvar="GITLAB_URL",
+    default=_default_gitlab_url,
 )
 @click.option(
     "--token",
     help="token (can be set as env variable GITLAB_TOKEN)",
     type=str,
     required=True,
-    default=DEFAULT_TOKEN,
+    envvar="GITLAB_TOKEN",
 )
 @click.option(
     "--project",
     help="GitLab project name (defaults to env variable GITLAB_PROJECT)",
     type=str,
     required=False,
-    default=DEFAULT_PROJECT,
+    envvar="GITLAB_PROJECT",
 )
 @click.option(
     "--branch",
@@ -280,21 +284,22 @@ def run_job(url, token, project, branch, variables):
     help="GitLab instance API URL (defaults to gitlab.com)",
     type=str,
     required=False,
-    default=DEFAULT_URL,
+    envvar="GITLAB_URL",
+    default=_default_gitlab_url,
 )
 @click.option(
     "--token",
     help="token (can be set as env variable GITLAB_TOKEN)",
     type=str,
     required=True,
-    default=DEFAULT_TOKEN,
+    envvar="GITLAB_TOKEN",
 )
 @click.option(
     "--project",
     help="GitLab project name (defaults to env variable GITLAB_PROJECT)",
     type=str,
     required=False,
-    default=DEFAULT_PROJECT,
+    envvar="GITLAB_PROJECT",
 )
 def get_project_id(url, project, token):
     if not url:

--- a/developers_chamber/scripts/jira.py
+++ b/developers_chamber/scripts/jira.py
@@ -1,4 +1,3 @@
-import os
 
 import click
 
@@ -12,15 +11,10 @@ from developers_chamber.jira_utils import show_issue as show_issue_func
 from developers_chamber.scripts import cli
 from developers_chamber.types import TimedeltaType
 
-url = os.environ.get("JIRA_URL")
-username = os.environ.get("JIRA_USERNAME")
-api_key = os.environ.get("JIRA_API_KEY")
-jql = os.environ.get(
-    "JIRA_JQL",
+DEFAULT_JQL = (
     'project = {project_key} and assignee = currentUser() and status not in ("Done", "Canceled", "Closed") and sprint !'
-    "= null order by created DESC",
+    "= null order by created DESC"
 )
-project_key = os.environ.get("JIRA_PROJECT_KEY")
 
 
 @cli.group()
@@ -29,9 +23,9 @@ def jira():
 
 
 @jira.command()
-@click.option("--url", "-u", help="Jira URL", type=str, required=True, default=url)
+@click.option("--url", "-u", help="Jira URL", type=str, required=True, envvar="JIRA_URL")
 @click.option(
-    "--username", "-a", help="Jira username", type=str, required=True, default=username
+    "--username", "-a", help="Jira username", type=str, required=True, envvar="JIRA_USERNAME"
 )
 @click.option(
     "--api-key",
@@ -39,16 +33,16 @@ def jira():
     help="Jira API key/password",
     type=str,
     required=True,
-    default=api_key,
+    envvar="JIRA_API_KEY",
 )
 @click.option(
     "--project-key",
     help="Jira project key",
     type=str,
     required=False,
-    default=project_key,
+    envvar="JIRA_PROJECT_KEY",
 )
-@click.option("--jql", help="JQL", type=str, required=True, default=jql)
+@click.option("--jql", help="JQL", type=str, required=True, envvar="JIRA_JQL", default=DEFAULT_JQL)
 def my_issues(url, username, api_key, project_key, jql):
     """
     List open Jira tasks for the current user.
@@ -57,9 +51,9 @@ def my_issues(url, username, api_key, project_key, jql):
 
 
 @jira.command()
-@click.option("--url", "-u", help="Jira URL", type=str, required=True, default=url)
+@click.option("--url", "-u", help="Jira URL", type=str, required=True, envvar="JIRA_URL")
 @click.option(
-    "--username", "-a", help="Jira username", type=str, required=True, default=username
+    "--username", "-a", help="Jira username", type=str, required=True, envvar="JIRA_USERNAME"
 )
 @click.option(
     "--api-key",
@@ -67,14 +61,14 @@ def my_issues(url, username, api_key, project_key, jql):
     help="Jira API key/password",
     type=str,
     required=True,
-    default=api_key,
+    envvar="JIRA_API_KEY",
 )
 @click.option(
     "--project-key",
     help="Jira project key",
     type=str,
     required=False,
-    default=project_key,
+    envvar="JIRA_PROJECT_KEY",
 )
 @click.option("--issue-key", "-i", help="key of the task", type=str, required=True)
 def get_branch_name(url, username, api_key, project_key, issue_key):
@@ -85,9 +79,9 @@ def get_branch_name(url, username, api_key, project_key, issue_key):
 
 
 @jira.command()
-@click.option("--url", "-u", help="Jira URL", type=str, required=True, default=url)
+@click.option("--url", "-u", help="Jira URL", type=str, required=True, envvar="JIRA_URL")
 @click.option(
-    "--username", "-a", help="Jira username", type=str, required=True, default=username
+    "--username", "-a", help="Jira username", type=str, required=True, envvar="JIRA_USERNAME"
 )
 @click.option(
     "--api-key",
@@ -95,14 +89,14 @@ def get_branch_name(url, username, api_key, project_key, issue_key):
     help="Jira API key/password",
     type=str,
     required=True,
-    default=api_key,
+    envvar="JIRA_API_KEY",
 )
 @click.option(
     "--project-key",
     help="Jira project key",
     type=str,
     required=False,
-    default=project_key,
+    envvar="JIRA_PROJECT_KEY",
 )
 @click.option("--issue-key", "-i", help="key of the task", type=str)
 def show_issue(url, username, api_key, project_key, issue_key):
@@ -113,9 +107,9 @@ def show_issue(url, username, api_key, project_key, issue_key):
 
 
 @jira.command()
-@click.option("--url", "-u", help="Jira URL", type=str, required=True, default=url)
+@click.option("--url", "-u", help="Jira URL", type=str, required=True, envvar="JIRA_URL")
 @click.option(
-    "--username", "-a", help="Jira username", type=str, required=True, default=username
+    "--username", "-a", help="Jira username", type=str, required=True, envvar="JIRA_USERNAME"
 )
 @click.option(
     "--api-key",
@@ -123,14 +117,14 @@ def show_issue(url, username, api_key, project_key, issue_key):
     help="Jira API key/password",
     type=str,
     required=True,
-    default=api_key,
+    envvar="JIRA_API_KEY",
 )
 @click.option(
     "--project-key",
     help="Jira project key",
     type=str,
     required=False,
-    default=project_key,
+    envvar="JIRA_PROJECT_KEY",
 )
 @click.option("--issue-key", "-i", help="key of the task", type=str)
 @click.option(
@@ -152,9 +146,9 @@ def log_issue_time(url, username, api_key, project_key, issue_key, time_spend, c
 
 
 @jira.command()
-@click.option("--url", "-u", help="Jira URL", type=str, required=True, default=url)
+@click.option("--url", "-u", help="Jira URL", type=str, required=True, envvar="JIRA_URL")
 @click.option(
-    "--username", "-a", help="Jira username", type=str, required=True, default=username
+    "--username", "-a", help="Jira username", type=str, required=True, envvar="JIRA_USERNAME"
 )
 @click.option(
     "--api-key",
@@ -162,14 +156,14 @@ def log_issue_time(url, username, api_key, project_key, issue_key, time_spend, c
     help="Jira API key/password",
     type=str,
     required=True,
-    default=api_key,
+    envvar="JIRA_API_KEY",
 )
 @click.option(
     "--project-key",
     help="Jira project key",
     type=str,
     required=False,
-    default=project_key,
+    envvar="JIRA_PROJECT_KEY",
 )
 @click.option("--issue-key", "-i", help="key of the task", type=str)
 def print_issue_worklog(url, username, api_key, project_key, issue_key):
@@ -183,9 +177,9 @@ def print_issue_worklog(url, username, api_key, project_key, issue_key):
 
 
 @jira.command()
-@click.option("--url", "-u", help="Jira URL", type=str, required=True, default=url)
+@click.option("--url", "-u", help="Jira URL", type=str, required=True, envvar="JIRA_URL")
 @click.option(
-    "--username", "-a", help="Jira username", type=str, required=True, default=username
+    "--username", "-a", help="Jira username", type=str, required=True, envvar="JIRA_USERNAME"
 )
 @click.option(
     "--api-key",
@@ -193,7 +187,7 @@ def print_issue_worklog(url, username, api_key, project_key, issue_key):
     help="Jira API key/password",
     type=str,
     required=True,
-    default=api_key,
+    envvar="JIRA_API_KEY",
 )
 @click.option("--jql", help="JQL", type=str, required=True)
 @click.option("--transition", help="Jira transition name", type=str, required=True)

--- a/developers_chamber/scripts/project.py
+++ b/developers_chamber/scripts/project.py
@@ -4,6 +4,8 @@ from datetime import date
 import click
 
 from developers_chamber.click.options import (
+    COMMA_SEPARATED,
+    CommaSeparatedPathType,
     ContainerCommandType,
     ContainerDirToCopyType,
     ContainerEnvironment,
@@ -25,63 +27,11 @@ from developers_chamber.project_utils import docker_clean, set_hosts
 from developers_chamber.scripts import cli
 from developers_chamber.utils import INSTALLED_MODULES
 
-default_project_name = os.environ.get("PROJECT_DOCKER_COMPOSE_PROJECT_NAME")
-default_compose_files = (
-    os.environ.get("PROJECT_DOCKER_COMPOSE_FILES").split(",")
-    if os.environ.get("PROJECT_DOCKER_COMPOSE_FILES")
-    else None
-)
-default_domains = (
-    os.environ.get("PROJECT_DOMAINS").split(",")
-    if os.environ.get("PROJECT_DOMAINS")
-    else None
-)
-default_containers = (
-    os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS").split(",")
-    if os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS")
-    else None
-)
-default_up_containers = (
-    os.environ.get("PROJECT_DOCKER_COMPOSE_DEFAULT_UP_CONTAINERS").split(",")
-    if os.environ.get("PROJECT_DOCKER_COMPOSE_DEFAULT_UP_CONTAINERS")
-    else None
-)
-default_var_dirs = (
-    os.environ.get("PROJECT_DOCKER_COMPOSE_VAR_DIRS").split(",")
-    if os.environ.get("PROJECT_DOCKER_COMPOSE_VAR_DIRS")
-    else None
-)
-default_containers_dir_to_copy = (
-    os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY").split(",")
-    if os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY")
-    else None
-)
-default_containers_install_command = (
-    os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS_INSTALL_COMMAND").split(",")
-    if os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS_INSTALL_COMMAND")
-    else None
-)
-default_containers_env = (
-    os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS_ENV")
-    if os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS_ENV")
-    else None
-)
-default_library_dir = os.environ.get("PROJECT_LIBRARY_DIR")
 
-jira_url = os.environ.get("JIRA_URL")
-jira_username = os.environ.get("JIRA_USERNAME")
-jira_api_key = os.environ.get("JIRA_API_KEY")
-jira_project_key = os.environ.get("JIRA_PROJECT_KEY")
-
-toggl_api_key = os.environ.get("TOGGL_API_KEY")
-toggl_project_id = os.environ.get("TOGGL_PROJECT_ID")
-toggl_workspace_id = os.environ.get("TOGGL_WORKSPACE_ID")
-
-source_branch_name = os.environ.get("PROJECT_SOURCE_BRANCH_NAME", "next")
-bitbucket_username = os.environ.get("BITBUCKET_USERNAME")
-bitbucket_password = os.environ.get("BITBUCKET_PASSWORD")
-bitbucket_destination_branch_name = os.environ.get("BITBUCKET_BRANCH_NAME", "next")
-bitbucket_repository_name = os.environ.get("BITBUCKET_REPOSITORY")
+def _default_first_container():
+    """The run and exec commands work on a single container, take the first configured one."""
+    containers = os.environ.get("PROJECT_DOCKER_COMPOSE_CONTAINERS")
+    return containers.split(",")[:1] if containers else None
 
 
 @cli.group()
@@ -94,10 +44,10 @@ def project():
     "--domain",
     "-d",
     help="Domain which will be set to the hosts file",
-    type=str,
+    type=COMMA_SEPARATED,
     required=True,
     multiple=True,
-    default=default_domains,
+    envvar="PROJECT_DOMAINS",
 )
 def set_domain(domain):
     """
@@ -114,7 +64,7 @@ def set_domain(domain):
     help="Name of the project",
     type=str,
     required=True,
-    default=default_project_name,
+    envvar="PROJECT_DOCKER_COMPOSE_PROJECT_NAME",
 )
 @click.option(
     "--compose-file",
@@ -122,8 +72,8 @@ def set_domain(domain):
     help="Compose file",
     required=True,
     multiple=True,
-    default=default_compose_files,
-    type=click.Path(exists=True),
+    envvar="PROJECT_DOCKER_COMPOSE_FILES",
+    type=CommaSeparatedPathType(exists=True),
 )
 @click.option(
     "--container", "-c", help="Container name", type=str, required=False, multiple=True
@@ -135,14 +85,14 @@ def set_domain(domain):
     "DOCKER_CONTAINER_NAME:CONTAINER_DIRECTORY:HOST_DIRECTORY",
     type=ContainerDirToCopyType(),
     multiple=True,
-    default=default_containers_dir_to_copy,
+    envvar="PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY",
 )
 @click.option(
     "--env",
     "env",
     help="Environment variables",
     type=ContainerEnvironment(),
-    default=default_containers_env,
+    envvar="PROJECT_DOCKER_COMPOSE_CONTAINERS_ENV",
 )
 def build(project_name, compose_file, container, container_dir_to_copy, env):
     """
@@ -163,7 +113,7 @@ def build(project_name, compose_file, container, container_dir_to_copy, env):
     help="Name of the project",
     type=str,
     required=True,
-    default=default_project_name,
+    envvar="PROJECT_DOCKER_COMPOSE_PROJECT_NAME",
 )
 @click.option(
     "--compose-file",
@@ -171,8 +121,8 @@ def build(project_name, compose_file, container, container_dir_to_copy, env):
     help="Compose file",
     required=True,
     multiple=True,
-    default=default_compose_files,
-    type=click.Path(exists=True),
+    envvar="PROJECT_DOCKER_COMPOSE_FILES",
+    type=CommaSeparatedPathType(exists=True),
 )
 @click.option(
     "--container",
@@ -181,14 +131,14 @@ def build(project_name, compose_file, container, container_dir_to_copy, env):
     type=str,
     required=True,
     multiple=True,
-    default=default_containers[:1] if default_containers else None,
+    default=_default_first_container,
 )
 @click.option(
     "--env",
     "env",
     help="Environment variables",
     type=ContainerEnvironment(),
-    default=default_containers_env,
+    envvar="PROJECT_DOCKER_COMPOSE_CONTAINERS_ENV",
 )
 @click.pass_context
 def run(ctx, project_name, compose_file, container, command, env):
@@ -211,7 +161,7 @@ def run(ctx, project_name, compose_file, container, command, env):
     help="Name of the project",
     type=str,
     required=True,
-    default=default_project_name,
+    envvar="PROJECT_DOCKER_COMPOSE_PROJECT_NAME",
 )
 @click.option(
     "--compose-file",
@@ -219,8 +169,8 @@ def run(ctx, project_name, compose_file, container, command, env):
     help="Compose file",
     required=True,
     multiple=True,
-    default=default_compose_files,
-    type=click.Path(exists=True),
+    envvar="PROJECT_DOCKER_COMPOSE_FILES",
+    type=CommaSeparatedPathType(exists=True),
 )
 @click.option(
     "--container",
@@ -229,14 +179,14 @@ def run(ctx, project_name, compose_file, container, command, env):
     type=str,
     required=True,
     multiple=True,
-    default=default_containers[:1] if default_containers else None,
+    default=_default_first_container,
 )
 @click.option(
     "--env",
     "env",
     help="Environment variables",
     type=ContainerEnvironment(),
-    default=default_containers_env,
+    envvar="PROJECT_DOCKER_COMPOSE_CONTAINERS_ENV",
 )
 @click.pass_context
 def exec_command(ctx, project_name, compose_file, container, command, env):
@@ -256,7 +206,7 @@ def exec_command(ctx, project_name, compose_file, container, command, env):
     help="Name of the project",
     type=str,
     required=True,
-    default=default_project_name,
+    envvar="PROJECT_DOCKER_COMPOSE_PROJECT_NAME",
 )
 @click.option(
     "--compose-file",
@@ -264,17 +214,17 @@ def exec_command(ctx, project_name, compose_file, container, command, env):
     help="Compose file",
     required=True,
     multiple=True,
-    default=default_compose_files,
-    type=click.Path(exists=True),
+    envvar="PROJECT_DOCKER_COMPOSE_FILES",
+    type=CommaSeparatedPathType(exists=True),
 )
 @click.option(
     "--container",
     "-c",
     help="Container name",
-    type=str,
+    type=COMMA_SEPARATED,
     required=False,
     multiple=True,
-    default=default_up_containers,
+    envvar="PROJECT_DOCKER_COMPOSE_DEFAULT_UP_CONTAINERS",
 )
 @click.option(
     "--all",
@@ -289,7 +239,7 @@ def exec_command(ctx, project_name, compose_file, container, command, env):
     "env",
     help="Environment variables",
     type=ContainerEnvironment(),
-    default=default_containers_env,
+    envvar="PROJECT_DOCKER_COMPOSE_CONTAINERS_ENV",
 )
 def up(project_name, compose_file, container, all_containers, env):
     """
@@ -307,7 +257,7 @@ def up(project_name, compose_file, container, all_containers, env):
     help="Name of the project",
     type=str,
     required=True,
-    default=default_project_name,
+    envvar="PROJECT_DOCKER_COMPOSE_PROJECT_NAME",
 )
 @click.option(
     "--compose-file",
@@ -315,8 +265,8 @@ def up(project_name, compose_file, container, all_containers, env):
     help="Compose file",
     required=True,
     multiple=True,
-    default=default_compose_files,
-    type=click.Path(exists=True),
+    envvar="PROJECT_DOCKER_COMPOSE_FILES",
+    type=CommaSeparatedPathType(exists=True),
 )
 @click.option(
     "--container", "-c", help="Container name", type=str, required=False, multiple=True
@@ -335,7 +285,7 @@ def stop(project_name, compose_file, container):
     help="Name of the project",
     type=str,
     required=True,
-    default=default_project_name,
+    envvar="PROJECT_DOCKER_COMPOSE_PROJECT_NAME",
 )
 @click.option(
     "--compose-file",
@@ -343,16 +293,16 @@ def stop(project_name, compose_file, container):
     help="Compose file",
     required=True,
     multiple=True,
-    default=default_compose_files,
-    type=click.Path(exists=True),
+    envvar="PROJECT_DOCKER_COMPOSE_FILES",
+    type=CommaSeparatedPathType(exists=True),
 )
 @click.option(
     "--var-dir",
     "-v",
     help="Variable content directory",
-    type=str,
+    type=COMMA_SEPARATED,
     required=False,
-    default=default_var_dirs,
+    envvar="PROJECT_DOCKER_COMPOSE_VAR_DIRS",
     multiple=True,
 )
 @click.option(
@@ -363,7 +313,7 @@ def stop(project_name, compose_file, container):
     type=ContainerDirToCopyType(),
     required=False,
     multiple=True,
-    default=default_containers_dir_to_copy,
+    envvar="PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY",
 )
 @click.option(
     "--install-container-command",
@@ -372,7 +322,7 @@ def stop(project_name, compose_file, container):
     type=ContainerCommandType(),
     required=False,
     multiple=True,
-    default=default_containers_install_command,
+    envvar="PROJECT_DOCKER_COMPOSE_CONTAINERS_INSTALL_COMMAND",
 )
 def install(
     project_name,
@@ -400,7 +350,7 @@ def install(
     help="Name of the project",
     type=str,
     required=True,
-    default=default_project_name,
+    envvar="PROJECT_DOCKER_COMPOSE_PROJECT_NAME",
 )
 @click.option(
     "--container-dir-to-copy",
@@ -410,7 +360,7 @@ def install(
     type=ContainerDirToCopyType(),
     required=False,
     multiple=True,
-    default=default_containers_dir_to_copy,
+    envvar="PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY",
 )
 def copy_container_dirs(project_name, container_dir_to_copy):
     """
@@ -432,7 +382,7 @@ def copy_container_dirs(project_name, container_dir_to_copy):
     "-d",
     help="Library destination directory",
     required=True,
-    default=default_library_dir,
+    envvar="PROJECT_LIBRARY_DIR",
     type=click.Path(exists=True),
 )
 def bind_library(library_source_dir, library_destination_dir):
@@ -486,35 +436,35 @@ if (
 
     @task.command()
     @click.option(
-        "--jira-url", help="Jira URL", type=str, required=True, default=jira_url
+        "--jira-url", help="Jira URL", type=str, required=True, envvar="JIRA_URL"
     )
     @click.option(
         "--jira-username",
         help="Jira username",
         type=str,
         required=True,
-        default=jira_username,
+        envvar="JIRA_USERNAME",
     )
     @click.option(
         "--jira-api-key",
         help="Jira API key/password",
         type=str,
         required=True,
-        default=jira_api_key,
+        envvar="JIRA_API_KEY",
     )
     @click.option(
         "--jira_project-key",
         help="Jira project key",
         type=str,
         required=False,
-        default=jira_project_key,
+        envvar="JIRA_PROJECT_KEY",
     )
     @click.option(
         "--toggl-api-key",
         help="toggle API key",
         type=str,
         required=True,
-        default=toggl_api_key,
+        envvar="TOGGL_API_KEY",
     )
     @click.option(
         "--toggl-workspace-id",
@@ -522,7 +472,7 @@ if (
         help="toggl workspace ID",
         type=str,
         required=False,
-        default=toggl_workspace_id,
+        envvar="TOGGL_WORKSPACE_ID",
     )
     @click.option(
         "--toggl-project-id",
@@ -530,7 +480,7 @@ if (
         help="toggl project ID",
         type=str,
         required=False,
-        default=toggl_project_id,
+        envvar="TOGGL_PROJECT_ID",
     )
     @click.option("--issue-key", "-i", help="key of the task", type=str)
     def start(
@@ -561,28 +511,28 @@ if (
 
     @task.command()
     @click.option(
-        "--jira-url", help="Jira URL", type=str, required=True, default=jira_url
+        "--jira-url", help="Jira URL", type=str, required=True, envvar="JIRA_URL"
     )
     @click.option(
         "--jira-username",
         help="Jira username",
         type=str,
         required=True,
-        default=jira_username,
+        envvar="JIRA_USERNAME",
     )
     @click.option(
         "--jira-api-key",
         help="Jira API key/password",
         type=str,
         required=True,
-        default=jira_api_key,
+        envvar="JIRA_API_KEY",
     )
     @click.option(
         "--toggl-api-key",
         help="toggle API key",
         type=str,
         required=True,
-        default=toggl_api_key,
+        envvar="TOGGL_API_KEY",
     )
     def stop(jira_url, jira_username, jira_api_key, toggl_api_key):
         """
@@ -592,35 +542,35 @@ if (
 
     @task.command()
     @click.option(
-        "--jira-url", help="Jira URL", type=str, required=True, default=jira_url
+        "--jira-url", help="Jira URL", type=str, required=True, envvar="JIRA_URL"
     )
     @click.option(
         "--jira-username",
         help="Jira username",
         type=str,
         required=True,
-        default=jira_username,
+        envvar="JIRA_USERNAME",
     )
     @click.option(
         "--jira-api-key",
         help="Jira API key/password",
         type=str,
         required=True,
-        default=jira_api_key,
+        envvar="JIRA_API_KEY",
     )
     @click.option(
         "--jira-project-key",
         help="Jira project key",
         type=str,
         required=False,
-        default=jira_project_key,
+        envvar="JIRA_PROJECT_KEY",
     )
     @click.option(
         "--source_branch_name",
         "-s",
         help="source branch name",
         type=str,
-        default=source_branch_name,
+        envvar="PROJECT_SOURCE_BRANCH_NAME", default="next",
     )
     @click.option("--issue-key", "-i", help="key of the task", type=str, required=True)
     def create_branch_from_issue(
@@ -647,7 +597,7 @@ if (
 
     @task.command()
     @click.option(
-        "--jira-url", "-u", help="Jira URL", type=str, required=True, default=jira_url
+        "--jira-url", "-u", help="Jira URL", type=str, required=True, envvar="JIRA_URL"
     )
     @click.option(
         "--jira-username",
@@ -655,7 +605,7 @@ if (
         help="Jira username",
         type=str,
         required=True,
-        default=jira_username,
+        envvar="JIRA_USERNAME",
     )
     @click.option(
         "--jira-api-key",
@@ -663,28 +613,28 @@ if (
         help="Jira API key/password",
         type=str,
         required=True,
-        default=jira_api_key,
+        envvar="JIRA_API_KEY",
     )
     @click.option(
         "--bitbucket-username",
         help="username",
         type=str,
         required=True,
-        default=bitbucket_username,
+        envvar="BITBUCKET_USERNAME",
     )
     @click.option(
         "--bitbucket-password",
         help="password",
         type=str,
         required=True,
-        default=bitbucket_password,
+        envvar="BITBUCKET_PASSWORD",
     )
     @click.option(
         "--bitbucket-destination-branch-name",
         help="destination bitbucket branch name",
         type=str,
         required=True,
-        default=bitbucket_destination_branch_name,
+        envvar="BITBUCKET_BRANCH_NAME", default="next",
     )
     @click.option(
         "--bitbucket-repository-name",
@@ -692,7 +642,7 @@ if (
         help="bitbucket repository name",
         type=str,
         required=True,
-        default=bitbucket_repository_name,
+        envvar="BITBUCKET_REPOSITORY",
     )
     def create_or_update_pull_request(
         jira_url,
@@ -722,28 +672,28 @@ if (
 
     @task.command()
     @click.option(
-        "--jira-url", help="Jira URL", type=str, required=True, default=jira_url
+        "--jira-url", help="Jira URL", type=str, required=True, envvar="JIRA_URL"
     )
     @click.option(
         "--jira-username",
         help="Jira username",
         type=str,
         required=True,
-        default=jira_username,
+        envvar="JIRA_USERNAME",
     )
     @click.option(
         "--jira-api-key",
         help="Jira API key/password",
         type=str,
         required=True,
-        default=jira_api_key,
+        envvar="JIRA_API_KEY",
     )
     @click.option(
         "--toggl-api-key",
         help="toggle API key",
         type=str,
         required=True,
-        default=toggl_api_key,
+        envvar="TOGGL_API_KEY",
     )
     @click.option(
         "--toggl-workspace-id",
@@ -751,7 +701,7 @@ if (
         help="toggl workspace ID",
         type=str,
         required=False,
-        default=toggl_workspace_id,
+        envvar="TOGGL_WORKSPACE_ID",
     )
     @click.option(
         "--toggl-project-id",
@@ -759,7 +709,7 @@ if (
         help="toggl project ID",
         type=str,
         required=False,
-        default=toggl_project_id,
+        envvar="TOGGL_PROJECT_ID",
     )
     @click.option(
         "--from-date",
@@ -806,14 +756,14 @@ if (
         help="username",
         type=str,
         required=True,
-        default=bitbucket_username,
+        envvar="BITBUCKET_USERNAME",
     )
     @click.option(
         "--bitbucket-password",
         help="password",
         type=str,
         required=True,
-        default=bitbucket_password,
+        envvar="BITBUCKET_PASSWORD",
     )
     @click.option(
         "--bitbucket-repository-name",
@@ -821,7 +771,7 @@ if (
         help="bitbucket repository name",
         type=str,
         required=True,
-        default=bitbucket_repository_name,
+        envvar="BITBUCKET_REPOSITORY",
     )
     @click.option("--branch-name", help="git branch name", type=str, required=False)
     def print_last_commit_build(

--- a/developers_chamber/scripts/sh.py
+++ b/developers_chamber/scripts/sh.py
@@ -1,15 +1,19 @@
+import shlex
+
 import click
 
 from developers_chamber.scripts import cli
 from developers_chamber.utils import call_command
 
 
-@cli.command(
-    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True)
-)
-@click.argument("command")
+@cli.command(context_settings=dict(ignore_unknown_options=True))
+@click.argument("command", nargs=-1, required=True)
 def sh(command):
     """
     Run shell command and print the result.
+
+    The command can be given as one quoted string or as the rest of the command line. A single
+    argument is passed to the shell as it is, so it may contain the shell operators, while more
+    arguments are joined back with their quoting kept.
     """
-    call_command(command)
+    call_command(command[0] if len(command) == 1 else shlex.join(command))

--- a/developers_chamber/scripts/slack.py
+++ b/developers_chamber/scripts/slack.py
@@ -1,4 +1,3 @@
-import os
 
 import click
 
@@ -8,7 +7,6 @@ from developers_chamber.slack_utils import (
 )
 from developers_chamber.utils import MIGRATIONS_PATTERN
 
-slack_bot_token = os.environ.get("SLACK_BOT_TOKEN")
 TARGET_BRANCH = "master"
 
 
@@ -19,7 +17,7 @@ def slack():
 
 @slack.command()
 @click.option(
-    "--token", help="Slack bot token", type=str, required=True, default=slack_bot_token
+    "--token", help="Slack bot token", type=str, required=True, envvar="SLACK_BOT_TOKEN"
 )
 @click.option(
     "--channel",

--- a/developers_chamber/scripts/toggle.py
+++ b/developers_chamber/scripts/toggle.py
@@ -1,4 +1,3 @@
-import os
 from datetime import date
 
 import click
@@ -13,9 +12,6 @@ from developers_chamber.toggle_utils import (
 )
 from developers_chamber.utils import pretty_time_delta
 
-api_key = os.environ.get("TOGGL_API_KEY")
-project_id = os.environ.get("TOGGL_PROJECT_ID")
-workspace_id = os.environ.get("TOGGL_WORKSPACE_ID")
 
 
 @cli.group()
@@ -31,7 +27,7 @@ def toggl():
     help="toggl workspace ID",
     type=str,
     required=False,
-    default=workspace_id,
+    envvar="TOGGL_WORKSPACE_ID",
 )
 @click.option(
     "--project-id",
@@ -39,10 +35,10 @@ def toggl():
     help="toggl project ID",
     type=str,
     required=False,
-    default=project_id,
+    envvar="TOGGL_PROJECT_ID",
 )
 @click.option(
-    "--api-key", "-k", help="toggle API key", type=str, required=True, default=api_key
+    "--api-key", "-k", help="toggle API key", type=str, required=True, envvar="TOGGL_API_KEY"
 )
 def start(description, workspace_id, project_id, api_key):
     """
@@ -56,7 +52,7 @@ def start(description, workspace_id, project_id, api_key):
 
 @toggl.command()
 @click.option(
-    "--api-key", "-k", help="toggle API key", type=str, required=True, default=api_key
+    "--api-key", "-k", help="toggle API key", type=str, required=True, envvar="TOGGL_API_KEY"
 )
 def stop(api_key):
     """
@@ -75,7 +71,7 @@ def stop(api_key):
 
 @toggl.command(name="print")
 @click.option(
-    "--api-key", "-k", help="toggle API key", type=str, required=True, default=api_key
+    "--api-key", "-k", help="toggle API key", type=str, required=True, envvar="TOGGL_API_KEY"
 )
 def print_toggl(api_key):
     """
@@ -96,7 +92,7 @@ def print_toggl(api_key):
     help="toggl workspace ID",
     type=str,
     required=False,
-    default=workspace_id,
+    envvar="TOGGL_WORKSPACE_ID",
 )
 @click.option(
     "--project-id",
@@ -104,7 +100,7 @@ def print_toggl(api_key):
     help="toggl project ID",
     type=str,
     required=False,
-    default=project_id,
+    envvar="TOGGL_PROJECT_ID",
 )
 @click.option("--description", "-d", help="task description", type=str)
 @click.option(
@@ -122,7 +118,7 @@ def print_toggl(api_key):
     default=str(date.today()),
 )
 @click.option(
-    "--api-key", "-k", help="toggle API key", type=str, required=True, default=api_key
+    "--api-key", "-k", help="toggle API key", type=str, required=True, envvar="TOGGL_API_KEY"
 )
 def print_report(workspace_id, project_id, description, from_date, to_date, api_key):
     """
@@ -147,7 +143,7 @@ def print_report(workspace_id, project_id, description, from_date, to_date, api_
     help="toggl workspace ID",
     type=str,
     required=False,
-    default=workspace_id,
+    envvar="TOGGL_WORKSPACE_ID",
 )
 @click.option(
     "--project-id",
@@ -155,7 +151,7 @@ def print_report(workspace_id, project_id, description, from_date, to_date, api_
     help="toggl project ID",
     type=str,
     required=False,
-    default=project_id,
+    envvar="TOGGL_PROJECT_ID",
 )
 @click.option("--description", "-d", help="task description", type=str)
 @click.option(
@@ -173,7 +169,7 @@ def print_report(workspace_id, project_id, description, from_date, to_date, api_
     default=str(date.today()),
 )
 @click.option(
-    "--api-key", "-k", help="toggle API key", type=str, required=True, default=api_key
+    "--api-key", "-k", help="toggle API key", type=str, required=True, envvar="TOGGL_API_KEY"
 )
 def print_report_tasks(
     workspace_id, project_id, description, from_date, to_date, api_key

--- a/developers_chamber/scripts/version.py
+++ b/developers_chamber/scripts/version.py
@@ -2,6 +2,7 @@ import os
 
 import click
 
+from developers_chamber.click.options import CommaSeparatedPathType
 from developers_chamber.scripts import cli
 from developers_chamber.types import (
     EnumType,
@@ -14,8 +15,9 @@ from developers_chamber.version_utils import (
 )
 from developers_chamber.version_utils import get_next_version, get_version
 
-default_version_files = os.environ.get("VERSION_FILES", "version.json").split(",")
-default_version_file_type = os.environ.get("VERSION_FILE_TYPE")
+def _default_version_file():
+    """The commands which work on a single file take the first configured one."""
+    return os.environ.get("VERSION_FILES", "version.json").split(",")[0]
 
 
 @cli.group()
@@ -45,16 +47,17 @@ def version():
     "--file",
     "-f",
     help="path to the version file",
-    default=default_version_files,
+    envvar="VERSION_FILES",
+    default=("version.json",),
     required=True,
     multiple=True,
-    type=click.Path(exists=True),
+    type=CommaSeparatedPathType(exists=True),
 )
 @click.option(
     "--file-type",
     help="version file type",
     type=EnumType(VersionFileType),
-    default=default_version_file_type,
+    envvar="VERSION_FILE_TYPE",
     required=False,
 )
 def bump_to_next(release_type, build_hash, pre_release, file, file_type):
@@ -96,7 +99,7 @@ def bump_to_next(release_type, build_hash, pre_release, file, file_type):
     "--file",
     "-f",
     help="path to the version file",
-    default=default_version_files[0],
+    default=_default_version_file,
     required=True,
     type=click.Path(exists=True),
 )
@@ -104,7 +107,7 @@ def bump_to_next(release_type, build_hash, pre_release, file, file_type):
     "--file-type",
     help="version file type",
     type=EnumType(VersionFileType),
-    default=default_version_file_type,
+    envvar="VERSION_FILE_TYPE",
     required=False,
 )
 def print_version(file, file_type):
@@ -139,7 +142,7 @@ def print_version(file, file_type):
     "--file",
     "-f",
     help="path to the version file",
-    default=default_version_files[0],
+    default=_default_version_file,
     required=True,
     type=click.Path(exists=True),
 )
@@ -147,7 +150,7 @@ def print_version(file, file_type):
     "--file-type",
     help="version file type",
     type=EnumType(VersionFileType),
-    default=default_version_file_type,
+    envvar="VERSION_FILE_TYPE",
     required=False,
 )
 def print_next(release_type, build_hash, pre_release, file, file_type):

--- a/developers_chamber/types.py
+++ b/developers_chamber/types.py
@@ -72,5 +72,7 @@ class TimedeltaType(ParamType):
                 continue
             raise self.fail("Invalid time delta: {}".format(value))
         if result_value:
-            seconds = unit * int(result_value)
+            # a trailing number carries no unit of its own, it must still be added to what
+            # the preceding units already gave
+            seconds += unit * int(result_value)
         return datetime.timedelta(seconds=seconds)

--- a/example/.pydev/base.yaml
+++ b/example/.pydev/base.yaml
@@ -1,0 +1,35 @@
+jira:
+  project_key: PROJ
+  url: https://example.atlassian.net
+
+version_files: [version.json]
+
+project:
+  library_dir: var/site-packages
+  domains: [example.local]
+  docker_compose:
+    project_name: example
+    files: [docker/compose.yaml]
+    default_up_containers: [base, static]
+    var_dirs: [var, var/data/media, var/data/static]
+    containers_dir_to_copy:
+      base:
+        /usr/local/lib/python3.11/site-packages: var/site-packages
+    containers_install_command:
+      base: ./manage.py compilemessages && ./manage.py migrate && ./manage.py collectstatic
+    containers_env:
+      DJANGO_SETTINGS_MODULE: example.settings.local
+
+aliases:
+  up: project up
+  up-all: project up -a
+  migrate: project run "./manage.py migrate $app"
+  build-js:
+    - project run -c static "build-js.sh"
+    - project run -c base "./manage.py collectstatic"
+  # an alias can carry a description shown in the help of the pydev commands
+  reset-db:
+    description: Drop the database and migrate it from scratch
+    command:
+      - project run "./manage.py reset_db --noinput"
+      - project run "./manage.py migrate"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+filterwarnings =
+    error

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="developers-chamber",
-    version="0.1.51",
+    version="1.0.0",
     description="A small plugin which help with development, deployment, git",
     keywords="django, skripts, easy live, git, bitbucket, Jira",
     author="Druids team",
@@ -23,6 +23,9 @@ setup(
         "PyYAML>=6.0.3",
     ],
     extras_require={
+        "test": [
+            "pytest>=8.0",
+        ],
         "slack": [
             "slack-sdk==3.21.3",
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def restore_environ():
+    """
+    Keep the environment of one test out of the others.
+
+    Loading a configuration writes arbitrary variables into ``os.environ``, which monkeypatch
+    cannot undo because it does not know about them.
+    """
+    original = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(original)
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    """Directory of a throwaway project which holds a .pydev configuration directory."""
+    (tmp_path / ".pydev").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def config_dir(config_path):
+    return config_path / ".pydev"
+
+
+@pytest.fixture
+def write_config(config_dir):
+    def write(name, content):
+        file = config_dir / name
+        file.write_text(content)
+        return file
+
+    return write
+
+
+@pytest.fixture
+def project_dir(tmp_path, monkeypatch):
+    """Empty directory which is the working directory of the test."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def version_file(project_dir):
+    """Writes a version file into the working directory and reads it back."""
+
+    class VersionFile:
+        path = project_dir
+
+        def write(self, name, content):
+            (project_dir / name).write_text(content)
+            return name
+
+        def write_version(self, version, name="version.json"):
+            return self.write(name, json.dumps({"version": version}))
+
+        def read_version(self, name="version.json"):
+            return json.loads((project_dir / name).read_text())["version"]
+
+    return VersionFile()
+
+
+@pytest.fixture
+def git_repo(project_dir):
+    """Throwaway git repository with a single commit on the master branch."""
+    git = pytest.importorskip("git", reason='requires the "git" extra')
+
+    repo = git.Repo.init(project_dir)
+    with repo.config_writer() as config:
+        config.set_value("user", "name", "Test")
+        config.set_value("user", "email", "test@example.com")
+    (project_dir / "version.json").write_text(json.dumps({"version": "1.2.3"}))
+    repo.index.add(["version.json"])
+    repo.index.commit("Initial commit")
+    repo.git.branch("-M", "master")
+    return repo

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -1,0 +1,38 @@
+import pytest
+
+from developers_chamber.click.alias import find_and_replace_command_variable
+
+
+@pytest.mark.parametrize(
+    ("arg", "command", "index", "expected"),
+    [
+        (
+            "--app=users",
+            "project run './manage.py migrate $app'",
+            1,
+            (True, "project run './manage.py migrate users'"),
+        ),
+        ("--app users", "project run '$app'", 1, (True, "project run 'users'")),
+        (
+            "--app-name=users",
+            "project run '$app_name'",
+            1,
+            (True, "project run 'users'"),
+        ),
+        ("users", "project run '$1'", 1, (True, "project run 'users'")),
+        ("users", "project run '$1'", 2, (False, "project run '$1'")),
+        ("--other=users", "project run '$app'", 1, (False, "project run '$app'")),
+        ("--app=users", "project run '$1'", 1, (True, "project run '--app=users'")),
+    ],
+    ids=[
+        "named argument",
+        "named argument separated by a space",
+        "dashes match an underscore variable",
+        "positional argument",
+        "index is respected",
+        "unknown name is left for the command",
+        "named argument falls back to its index",
+    ],
+)
+def test_command_variable_is_replaced(arg, command, index, expected):
+    assert find_and_replace_command_variable(arg, command, index) == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,344 @@
+import json
+import os
+
+import pytest
+
+from developers_chamber.config import (
+    ConfigError,
+    flatten_settings,
+    iter_config_files,
+    load_config,
+    load_settings_file,
+)
+
+
+class TestFlattenSettings:
+
+    def test_scalars_are_converted_to_upper_case_names_and_strings(self):
+        assert flatten_settings(
+            {"jira_project_key": "PROJ", "toggl_project_id": 42, "debug": True}
+        ) == {"JIRA_PROJECT_KEY": "PROJ", "TOGGL_PROJECT_ID": "42", "DEBUG": "true"}
+
+    def test_false_is_converted_to_false_string(self):
+        assert flatten_settings({"debug": False}) == {"DEBUG": "false"}
+
+    def test_nested_objects_are_joined_with_underscore(self):
+        assert flatten_settings(
+            {"project": {"docker_compose": {"files": "a.yaml"}}}
+        ) == {"PROJECT_DOCKER_COMPOSE_FILES": "a.yaml"}
+
+    def test_dashes_in_names_are_normalized_to_underscores(self):
+        assert flatten_settings(
+            {"project": {"docker-compose": {"var-dirs": "var"}}}
+        ) == {"PROJECT_DOCKER_COMPOSE_VAR_DIRS": "var"}
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"project_docker_compose_files": ["a.yaml", "b.yaml"]},
+            {"project": {"docker_compose": {"files": ["a.yaml", "b.yaml"]}}},
+            {"project": {"docker": {"compose": {"files": ["a.yaml", "b.yaml"]}}}},
+        ],
+        ids=["flat", "two levels", "three levels"],
+    )
+    def test_sections_can_be_split_at_any_underscore(self, data):
+        assert flatten_settings(data) == {
+            "PROJECT_DOCKER_COMPOSE_FILES": "a.yaml,b.yaml"
+        }
+
+    def test_lists_are_joined_with_comma(self):
+        assert flatten_settings(
+            {"version_files": ["version.json", "package.json"]}
+        ) == {"VERSION_FILES": "version.json,package.json"}
+
+    def test_empty_list_is_converted_to_empty_string(self):
+        assert flatten_settings({"version_files": []}) == {"VERSION_FILES": ""}
+
+    def test_none_value_is_left_out(self):
+        assert flatten_settings({"jira_url": None}) == {}
+
+    def test_root_element_must_be_an_object(self):
+        with pytest.raises(ConfigError, match="root element must be an object"):
+            flatten_settings(["a", "b"])
+
+    @pytest.mark.parametrize(
+        ("data", "message"),
+        [
+            (
+                {"project": {"files": {"a"}}},
+                'setting "project.files": unsupported value type set',
+            ),
+            (
+                {"project": {"files": [["a"]]}},
+                'setting "project.files": unsupported value type list',
+            ),
+        ],
+        ids=["unsupported type", "nested list"],
+    )
+    def test_invalid_value_is_reported_with_its_path(self, data, message):
+        with pytest.raises(ConfigError, match=message):
+            flatten_settings(data)
+
+
+class TestAliasesEncoder:
+
+    def test_object_is_encoded_to_json(self):
+        encoded = flatten_settings(
+            {
+                "aliases": {
+                    "up": "project up",
+                    "build-js": ["project run -c static", "project run -c base"],
+                }
+            }
+        )["ALIASES"]
+        assert json.loads(encoded) == {
+            "up": "project up",
+            "build-js": ["project run -c static", "project run -c base"],
+        }
+
+    def test_alias_names_are_not_normalized(self):
+        encoded = flatten_settings({"aliases": {"up-all": "project up -a"}})["ALIASES"]
+        assert json.loads(encoded) == {"up-all": "project up -a"}
+
+    def test_alias_with_a_description_is_encoded(self):
+        # the form which AliasCommand accepts besides a command and a list of commands
+        alias = {"description": "Start the project", "command": "project up"}
+        encoded = flatten_settings({"aliases": {"up": alias}})["ALIASES"]
+        assert json.loads(encoded) == {"up": alias}
+
+    def test_form_of_a_single_alias_is_left_to_alias_command(self):
+        assert json.loads(flatten_settings({"aliases": {"up": 42}})["ALIASES"]) == {
+            "up": 42
+        }
+
+    def test_json_string_is_kept_as_is(self):
+        assert (
+            flatten_settings({"aliases": '{"up": "project up"}'})["ALIASES"]
+            == '{"up": "project up"}'
+        )
+
+    def test_list_is_not_a_valid_value(self):
+        with pytest.raises(
+            ConfigError,
+            match='setting "aliases": must be an object of alias name to command',
+        ):
+            flatten_settings({"aliases": ["project up"]})
+
+
+def flatten_docker_compose(setting, value):
+    return flatten_settings({"project": {"docker_compose": {setting: value}}})[
+        "PROJECT_DOCKER_COMPOSE_{}".format(setting.upper())
+    ]
+
+
+class TestContainersDirToCopyEncoder:
+
+    setting = "containers_dir_to_copy"
+
+    def test_object_is_encoded_to_colon_separated_triples(self):
+        assert flatten_docker_compose(
+            self.setting,
+            {
+                "base": {"/usr/local/lib/site-packages": "var/site-packages"},
+                "static": {"/srv/node_modules": "var/node_modules"},
+            },
+        ) == (
+            "base:/usr/local/lib/site-packages:var/site-packages,"
+            "static:/srv/node_modules:var/node_modules"
+        )
+
+    def test_string_is_kept_as_is(self):
+        assert flatten_docker_compose(self.setting, "base:/a:var/a") == "base:/a:var/a"
+
+    def test_list_of_strings_is_joined_with_comma(self):
+        assert (
+            flatten_docker_compose(self.setting, ["base:/a:var/a", "static:/b:var/b"])
+            == "base:/a:var/a,static:/b:var/b"
+        )
+
+    def test_container_value_must_be_an_object(self):
+        with pytest.raises(
+            ConfigError,
+            match='setting "project.docker_compose.containers_dir_to_copy": container "base"',
+        ):
+            flatten_docker_compose(self.setting, {"base": "var/site-packages"})
+
+    def test_host_directory_must_be_a_string(self):
+        with pytest.raises(ConfigError, match='"/a" must be a string'):
+            flatten_docker_compose(self.setting, {"base": {"/a": ["var/a"]}})
+
+
+class TestContainersInstallCommandEncoder:
+
+    setting = "containers_install_command"
+
+    def test_object_is_encoded_to_colon_separated_pairs(self):
+        assert (
+            flatten_docker_compose(
+                self.setting, {"base": "./manage.py migrate", "static": "build-js.sh"}
+            )
+            == "base:./manage.py migrate,static:build-js.sh"
+        )
+
+    def test_string_is_kept_as_is(self):
+        assert (
+            flatten_docker_compose(self.setting, "base:./manage.py migrate")
+            == "base:./manage.py migrate"
+        )
+
+    def test_list_of_strings_is_joined_with_comma(self):
+        assert (
+            flatten_docker_compose(
+                self.setting, ["base:./manage.py migrate", "static:build-js.sh"]
+            )
+            == "base:./manage.py migrate,static:build-js.sh"
+        )
+
+    def test_command_must_be_a_string(self):
+        with pytest.raises(ConfigError, match='"base" must be a string'):
+            flatten_docker_compose(self.setting, {"base": ["./manage.py migrate"]})
+
+
+class TestContainersEnvEncoder:
+
+    setting = "containers_env"
+
+    def test_object_is_encoded_to_space_separated_pairs(self):
+        assert (
+            flatten_docker_compose(self.setting, {"DEBUG": "1", "ENV": "local"})
+            == "DEBUG=1 ENV=local"
+        )
+
+    def test_string_is_kept_as_is(self):
+        assert flatten_docker_compose(self.setting, "DEBUG=1") == "DEBUG=1"
+
+    def test_list_is_not_a_valid_value(self):
+        with pytest.raises(
+            ConfigError, match="must be an object of variable name to value"
+        ):
+            flatten_docker_compose(self.setting, ["DEBUG=1"])
+
+
+class TestLoadSettingsFile:
+
+    @pytest.mark.parametrize(
+        ("name", "content"),
+        [
+            ("base.yaml", "jira:\n  project_key: PROJ\n"),
+            ("base.yml", "jira:\n  project_key: PROJ\n"),
+            ("base.json", '{"jira": {"project_key": "PROJ"}}'),
+        ],
+        ids=["yaml", "yml", "json"],
+    )
+    def test_file_is_loaded(self, write_config, name, content):
+        assert load_settings_file(write_config(name, content)) == {
+            "JIRA_PROJECT_KEY": "PROJ"
+        }
+
+    def test_empty_file_is_loaded_as_no_settings(self, write_config):
+        assert load_settings_file(write_config("base.yaml", "")) == {}
+
+    @pytest.mark.parametrize(
+        ("name", "content"),
+        [("base.yaml", "jira: [\n"), ("base.json", "{")],
+        ids=["yaml", "json"],
+    )
+    def test_invalid_syntax_is_reported_with_the_file_name(
+        self, write_config, name, content
+    ):
+        with pytest.raises(
+            ConfigError, match='Invalid config file ".*{}"'.format(name)
+        ):
+            load_settings_file(write_config(name, content))
+
+    def test_invalid_structure_is_reported_with_the_file_name(self, write_config):
+        file = write_config("base.yaml", "aliases:\n  - project up\n")
+        with pytest.raises(
+            ConfigError, match='Invalid config file ".*base.yaml": setting "aliases"'
+        ):
+            load_settings_file(file)
+
+
+class TestIterConfigFiles:
+
+    def test_files_of_all_formats_are_returned_in_the_alphabetical_order(
+        self, write_config, config_dir
+    ):
+        for name in ("prod.yml", "dev.json", "base.conf", "extra.yaml"):
+            write_config(name, "")
+        assert [file.name for file in iter_config_files(config_dir)] == [
+            "base.conf",
+            "dev.json",
+            "extra.yaml",
+            "prod.yml",
+        ]
+
+    def test_files_starting_with_tilde_are_skipped(self, write_config, config_dir):
+        write_config("~prod.yaml", "")
+        write_config("base.yaml", "")
+        assert [file.name for file in iter_config_files(config_dir)] == ["base.yaml"]
+
+    def test_files_with_an_unknown_suffix_are_skipped(self, write_config, config_dir):
+        write_config("README.md", "")
+        write_config("base.yaml", "")
+        assert [file.name for file in iter_config_files(config_dir)] == ["base.yaml"]
+
+    def test_directories_are_skipped(self, write_config, config_dir):
+        (config_dir / "scripts.yaml").mkdir()
+        write_config("base.yaml", "")
+        assert [file.name for file in iter_config_files(config_dir)] == ["base.yaml"]
+
+    def test_missing_config_dir_returns_no_files(self, config_dir):
+        assert list(iter_config_files(config_dir / "missing")) == []
+
+
+class TestLoadConfig:
+
+    def test_settings_of_all_formats_are_loaded_into_the_environment(
+        self, write_config, config_path
+    ):
+        write_config("base.yaml", "jira:\n  project_key: PROJ\n")
+        write_config("dev.json", '{"jira": {"url": "https://jira.example.com"}}')
+        write_config("extra.conf", "JIRA_USERNAME=user\n")
+
+        load_config(config_paths=[config_path])
+
+        assert os.environ["JIRA_PROJECT_KEY"] == "PROJ"
+        assert os.environ["JIRA_URL"] == "https://jira.example.com"
+        assert os.environ["JIRA_USERNAME"] == "user"
+
+    def test_file_with_the_highest_order_overrides_the_previous_one(
+        self, write_config, config_path
+    ):
+        write_config("base.yaml", "jira:\n  project_key: BASE\n")
+        write_config("dev.conf", "JIRA_PROJECT_KEY=DEV\n")
+        write_config("prod.yaml", "jira:\n  project_key: PROD\n")
+
+        load_config(config_paths=[config_path])
+
+        assert os.environ["JIRA_PROJECT_KEY"] == "PROD"
+
+    def test_config_overrides_the_variable_set_in_the_environment(
+        self, write_config, config_path, monkeypatch
+    ):
+        monkeypatch.setenv("JIRA_PROJECT_KEY", "ENV")
+        write_config("base.yaml", "jira:\n  project_key: PROJ\n")
+
+        load_config(config_paths=[config_path])
+
+        assert os.environ["JIRA_PROJECT_KEY"] == "PROJ"
+
+    def test_project_config_overrides_the_general_one(
+        self, write_config, config_path, tmp_path
+    ):
+        general_path = tmp_path / "general"
+        (general_path / ".pydev").mkdir(parents=True)
+        (general_path / ".pydev" / "base.yaml").write_text(
+            "jira:\n  project_key: GENERAL\n  url: https://jira.example.com\n"
+        )
+        write_config("base.yaml", "jira:\n  project_key: PROJECT\n")
+
+        load_config(config_paths=[general_path, config_path])
+
+        assert os.environ["JIRA_PROJECT_KEY"] == "PROJECT"
+        assert os.environ["JIRA_URL"] == "https://jira.example.com"

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,0 +1,182 @@
+import pytest
+from click import UsageError
+
+pytest.importorskip("git", reason='requires the "git" extra')
+
+from developers_chamber.git_utils import (  # noqa: E402
+    _release_branch_name,
+    _release_prefix_part,
+    _release_tag_name,
+    bump_version_from_release_tag,
+    checkout_to_release_branch,
+    commit_version,
+    create_branch,
+    create_deployment_branch,
+    get_commit_hash,
+    get_current_branch_name,
+    get_current_issue_key,
+    get_remote_path,
+    get_remote_url,
+)
+from developers_chamber.version_utils import Version  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("git_repo")
+
+
+class TestReleaseNames:
+    """Names of the release branch and tag are pure, they need no repository."""
+
+    @pytest.mark.parametrize("release_prefix", [None, "", "   "])
+    def test_no_prefix_keeps_the_historical_naming(self, release_prefix):
+        assert _release_prefix_part(release_prefix) == ""
+
+    @pytest.mark.parametrize("release_prefix", ["habarico", "  habarico  "])
+    def test_prefix_is_stripped_and_joined_with_an_at_sign(self, release_prefix):
+        assert _release_prefix_part(release_prefix) == "habarico@"
+
+    def test_branch_name_uses_the_major_and_the_minor_version(self):
+        assert _release_branch_name(Version("1.2.3")) == "release/v1.2"
+
+    def test_branch_name_carries_the_prefix(self):
+        assert (
+            _release_branch_name(Version("1.2.3"), "habarico")
+            == "release/habarico@v1.2"
+        )
+
+    def test_tag_name_is_the_whole_version(self):
+        assert _release_tag_name(Version("1.2.3")) == "1.2.3"
+
+    @pytest.mark.parametrize(
+        ("version", "expected"),
+        [("1.2.3", "habarico@1.2.3"), ("1.2.3-beta.4", "habarico@1.2.3-beta.4")],
+    )
+    def test_tag_name_carries_the_prefix(self, version, expected):
+        assert _release_tag_name(Version(version), "habarico") == expected
+
+
+class TestBranch:
+
+    def test_current_branch_name_is_returned(self):
+        assert get_current_branch_name() == "master"
+
+    def test_branch_is_created_and_checked_out(self):
+        assert create_branch("master", "feature") == "feature"
+        assert get_current_branch_name() == "feature"
+
+    def test_existing_branch_is_reported(self):
+        create_branch("master", "feature")
+        with pytest.raises(UsageError, match='Branch "feature" already exist'):
+            create_branch("master", "feature")
+
+    def test_commit_hash_is_returned(self, git_repo):
+        assert get_commit_hash("master") == git_repo.heads["master"].object.hexsha
+
+    def test_unknown_branch_is_reported(self):
+        with pytest.raises(UsageError, match="Invalid branch name: missing"):
+            get_commit_hash("missing")
+
+    def test_issue_key_is_read_from_the_branch_name(self):
+        create_branch("master", "ABC-123-add-the-thing")
+        assert get_current_issue_key() == "ABC-123"
+
+    def test_branch_without_an_issue_key_returns_nothing(self):
+        assert get_current_issue_key() is None
+
+
+class TestCommitVersion:
+
+    def test_version_files_are_committed_and_tagged(self, git_repo, version_file):
+        version_file.write_version("1.3.0")
+        commit_version("1.3.0")
+        assert git_repo.head.commit.message.strip() == "Bump version to '1.3.0'"
+        assert [str(tag) for tag in git_repo.tags] == ["1.3.0"]
+
+    def test_tag_and_message_carry_the_release_prefix(self, git_repo, version_file):
+        version_file.write_version("1.3.0")
+        commit_version("1.3.0", release_prefix="habarico")
+        assert (
+            git_repo.head.commit.message.strip() == "Bump version to 'habarico@1.3.0'"
+        )
+        assert [str(tag) for tag in git_repo.tags] == ["habarico@1.3.0"]
+
+    def test_unchanged_version_files_are_reported(self):
+        with pytest.raises(UsageError, match="Version files was not changed"):
+            commit_version("1.3.0")
+
+    def test_existing_tag_is_reported(self, git_repo, version_file):
+        git_repo.create_tag("1.3.0")
+        version_file.write_version("1.3.0")
+        with pytest.raises(UsageError, match="Tag 1.3.0 already exists"):
+            commit_version("1.3.0")
+
+
+class TestBumpVersionFromReleaseTag:
+
+    @pytest.mark.parametrize(
+        "tag",
+        ["2.0.0", "habarico@2.0.0", "habarico/2.0.0"],
+        ids=["bare", "at", "slash"],
+    )
+    def test_version_is_taken_from_the_tag(self, git_repo, version_file, tag):
+        git_repo.create_tag(tag)
+        assert bump_version_from_release_tag() == "2.0.0"
+        assert version_file.read_version() == "2.0.0"
+
+    def test_tag_which_is_not_a_version_is_reported(self, git_repo):
+        git_repo.create_tag("nightly")
+        with pytest.raises(UsageError, match="Invalid release branch"):
+            bump_version_from_release_tag()
+
+
+class TestDeploymentBranch:
+
+    def test_deployment_branch_is_created_and_the_source_branch_restored(
+        self, git_repo
+    ):
+        assert create_deployment_branch("test") == "deploy-test"
+        assert get_current_branch_name() == "master"
+        assert "deploy-test" in [head.name for head in git_repo.heads]
+
+    def test_hot_deployment_branch_has_its_own_name(self):
+        assert create_deployment_branch("test", is_hot=True) == "deploy-test-hot"
+
+    def test_existing_deployment_branch_is_replaced_instead_of_stacked(self, git_repo):
+        create_deployment_branch("test")
+        create_deployment_branch("test")
+        deployment_commit = git_repo.heads["deploy-test"].commit
+        assert [parent.hexsha for parent in deployment_commit.parents] == [
+            git_repo.heads["master"].commit.hexsha
+        ]
+
+    def test_release_branch_is_read_back_from_the_deployment_commit(self, git_repo):
+        create_branch("master", "release/v1.2")
+        create_deployment_branch("test")
+        git_repo.git.checkout("deploy-test")
+        assert checkout_to_release_branch() == "release/v1.2"
+        assert get_current_branch_name() == "release/v1.2"
+
+    def test_double_quoted_deployment_commit_is_still_read(self, git_repo):
+        # the form written by the older versions of pydev
+        create_branch("master", "release/v1.2")
+        git_repo.git.checkout("HEAD", b="deploy-old")
+        git_repo.git.commit("--allow-empty", message='Deployment of "release/v1.2"')
+        assert checkout_to_release_branch() == "release/v1.2"
+
+    def test_commit_which_is_not_a_deployment_is_reported(self):
+        with pytest.raises(UsageError, match="Invalid deployment branch commit"):
+            checkout_to_release_branch()
+
+
+class TestRemote:
+
+    def test_ssh_remote_is_split_into_a_url_and_a_path(self, git_repo):
+        git_repo.create_remote("origin", "git@github.com:druids/developers-chamber.git")
+        assert get_remote_url() == "https://github.com"
+        assert get_remote_path() == "druids/developers-chamber"
+
+    def test_https_remote_with_credentials_is_split(self, git_repo):
+        git_repo.create_remote(
+            "origin", "https://oauth2:token@gitlab.example.com/group/project.git"
+        )
+        assert get_remote_url() == "https://gitlab.example.com"
+        assert get_remote_path() == "group/project"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,178 @@
+import click
+import pytest
+from click.testing import CliRunner
+
+from developers_chamber.click.options import (
+    COMMA_SEPARATED,
+    CommaSeparatedPathType,
+    ContainerCommandType,
+    ContainerDirToCopyType,
+    ContainerEnvironment,
+)
+
+
+def resolve_from_envvar(type_, env_value):
+    """Value which a repeatable option builds out of one environment variable."""
+
+    @click.command()
+    @click.option("-o", "values", type=type_, multiple=True, envvar="PYDEV_TEST")
+    def cmd(values):
+        click.echo(repr(values))
+
+    result = CliRunner().invoke(cmd, [], env={"PYDEV_TEST": env_value})
+    if result.exit_code:
+        raise AssertionError(result.output.strip())
+    return result.output.strip()
+
+
+class TestEnvvarSplitter:
+    """The comma separating the items of a setting is declared by the type, not by the option."""
+
+    def test_comma_separated_strings_are_split(self):
+        assert (
+            resolve_from_envvar(COMMA_SEPARATED, "base,static") == "('base', 'static')"
+        )
+
+    def test_single_item_stays_a_single_item(self):
+        assert resolve_from_envvar(COMMA_SEPARATED, "base") == "('base',)"
+
+    def test_comma_separated_paths_are_split(self):
+        assert (
+            resolve_from_envvar(CommaSeparatedPathType(), "a.yaml,b.yaml")
+            == "('a.yaml', 'b.yaml')"
+        )
+
+    def test_structured_items_are_split_and_converted(self):
+        assert (
+            resolve_from_envvar(ContainerCommandType(), "base:migrate,static:build")
+            == "(('base', 'migrate'), ('static', 'build'))"
+        )
+
+    def test_command_line_value_wins_over_the_environment(self):
+        @click.command()
+        @click.option(
+            "-o", "values", type=COMMA_SEPARATED, multiple=True, envvar="PYDEV_TEST"
+        )
+        def cmd(values):
+            click.echo(repr(values))
+
+        result = CliRunner().invoke(
+            cmd, ["-o", "other"], env={"PYDEV_TEST": "base,static"}
+        )
+        assert result.output.strip() == "('other',)"
+
+    def test_trailing_separator_is_reported_instead_of_being_ignored(self):
+        with pytest.raises(
+            AssertionError, match='format must be "DOCKER_CONTAINER_NAME:COMMAND"'
+        ):
+            resolve_from_envvar(ContainerCommandType(), "base:migrate,")
+
+
+class TestContainerDirToCopyType:
+
+    def test_value_is_parsed_into_the_declared_fields(self):
+        assert ContainerDirToCopyType().convert(
+            "base:/usr/local/lib:var/lib", None, None
+        ) == (
+            "base",
+            "/usr/local/lib",
+            "var/lib",
+        )
+
+    def test_value_with_a_wrong_number_of_fields_fails_with_the_declared_format(self):
+        with pytest.raises(
+            click.UsageError,
+            match='format must be "DOCKER_CONTAINER_NAME:CONTAINER_DIRECTORY:HOST_DIRECTORY"',
+        ):
+            ContainerDirToCopyType().convert("base:/usr/local/lib", None, None)
+
+    def test_encoded_object_is_parsed_back(self):
+        items = ContainerDirToCopyType.encode({"base": {"/usr/local/lib": "var/lib"}})
+        assert items == ["base:/usr/local/lib:var/lib"]
+        assert [
+            ContainerDirToCopyType().convert(item, None, None) for item in items
+        ] == [("base", "/usr/local/lib", "var/lib")]
+
+    def test_every_container_directory_is_a_separate_item(self):
+        assert ContainerDirToCopyType.encode(
+            {"base": {"/a": "var/a", "/b": "var/b"}, "static": {"/c": "var/c"}}
+        ) == ["base:/a:var/a", "base:/b:var/b", "static:/c:var/c"]
+
+    @pytest.mark.parametrize("value", ["base:/a:var/a", ["base:/a:var/a"]])
+    def test_string_and_list_are_kept_as_is(self, value):
+        assert ContainerDirToCopyType.encode(value) == value
+
+    def test_invalid_object_is_rejected(self):
+        with pytest.raises(ValueError, match='container "base" must be an object'):
+            ContainerDirToCopyType.encode({"base": "var/a"})
+
+
+class TestContainerCommandType:
+
+    def test_value_is_parsed_into_the_declared_fields(self):
+        assert ContainerCommandType().convert(
+            "base:./manage.py migrate", None, None
+        ) == (
+            "base",
+            "./manage.py migrate",
+        )
+
+    def test_empty_value_is_rejected(self):
+        # an empty item comes from a trailing separator in the setting, returning nothing here
+        # used to put a None into the option value which the caller could not unpack
+        with pytest.raises(
+            click.UsageError, match='format must be "DOCKER_CONTAINER_NAME:COMMAND"'
+        ):
+            ContainerCommandType().convert("", None, None)
+
+    def test_value_with_a_wrong_number_of_fields_fails_with_the_declared_format(self):
+        with pytest.raises(
+            click.UsageError, match='format must be "DOCKER_CONTAINER_NAME:COMMAND"'
+        ):
+            ContainerCommandType().convert("base", None, None)
+
+    def test_encoded_object_is_parsed_back(self):
+        items = ContainerCommandType.encode({"base": "./manage.py migrate"})
+        assert items == ["base:./manage.py migrate"]
+        assert [ContainerCommandType().convert(item, None, None) for item in items] == [
+            ("base", "./manage.py migrate")
+        ]
+
+    def test_command_must_be_a_string(self):
+        with pytest.raises(ValueError, match='"base" must be a string'):
+            ContainerCommandType.encode({"base": ["./manage.py migrate"]})
+
+
+class TestContainerEnvironment:
+
+    def test_value_is_parsed_into_variables(self):
+        assert ContainerEnvironment().convert("DEBUG=1 ENV=local", None, None) == {
+            "DEBUG": "1",
+            "ENV": "local",
+        }
+
+    def test_value_containing_the_assignment_is_kept_whole(self):
+        assert ContainerEnvironment().convert(
+            "DSN=db://user:pass@host?a=b", None, None
+        ) == {"DSN": "db://user:pass@host?a=b"}
+
+    def test_value_without_an_assignment_fails_with_the_declared_format(self):
+        with pytest.raises(
+            click.UsageError, match=r'format must be "NAME=VALUE \[NAME2=VALUE2\]"'
+        ):
+            ContainerEnvironment().convert("DEBUG", None, None)
+
+    def test_encoded_object_is_parsed_back(self):
+        value = ContainerEnvironment.encode({"DEBUG": "1", "ENV": "local"})
+        assert value == "DEBUG=1 ENV=local"
+        assert ContainerEnvironment().convert(value, None, None) == {
+            "DEBUG": "1",
+            "ENV": "local",
+        }
+
+    def test_string_is_kept_as_is(self):
+        assert ContainerEnvironment.encode("DEBUG=1") == "DEBUG=1"
+
+    def test_variable_value_must_be_a_string(self):
+        with pytest.raises(ValueError, match='"DEBUG" must be a string'):
+            ContainerEnvironment.encode({"DEBUG": {"a": "b"}})

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -1,0 +1,158 @@
+import sys
+
+import pytest
+from click import ClickException
+
+from developers_chamber.qa.base import QACheck, QACheckRunner, QAError
+from developers_chamber.qa.checks import (
+    MigrationFilenamesQACheck,
+    MissingTranslationsQACheck,
+)
+
+
+class RecordingQACheck(QACheck):
+    """Check which records that the cleanup ran instead of resetting the repository."""
+
+    name = "Recording check"
+
+    def __init__(self, error=None):
+        self.error = error
+        self.cleaned_up = False
+
+    def _run_check(self):
+        if self.error:
+            raise self.error
+
+    def _cleanup(self):
+        self.cleaned_up = True
+
+
+@pytest.fixture
+def run_checks(monkeypatch):
+    """Runs a check runner over a clean repository."""
+
+    def run(*checks):
+        monkeypatch.setattr(QACheckRunner, "_is_repo_clean", lambda self: True)
+        runner = QACheckRunner(*checks)
+        runner.run()
+        return runner
+
+    return run
+
+
+class TestQAError:
+
+    def test_output_is_stripped(self):
+        assert QAError("failed", "  boom  \n").output == "boom"
+
+    def test_output_is_optional(self):
+        assert QAError("failed").output is None
+
+    def test_message_is_kept(self):
+        assert str(QAError("failed", "boom")) == "failed"
+
+
+class TestQACheck:
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [("a/b/c.py", True), ("a/b/c.pyc", False), ("a/b/c.txt", False)],
+    )
+    def test_python_file_is_recognized(self, path, expected):
+        assert QACheck()._is_python_file(path) is expected
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("app/migrations/0001_initial.py", True),
+            ("app/models.py", False),
+            ("app/migrations/sub/0001_initial.py", False),
+        ],
+    )
+    def test_migration_file_is_recognized(self, path, expected):
+        assert QACheck()._is_migration_file(path) is expected
+
+    def test_command_is_built_from_the_config(self, monkeypatch):
+        monkeypatch.setenv("QA_TEST_COMMAND", "run tests")
+        assert QACheck()._get_command_from_config(
+            "QA_TEST_COMMAND"
+        ) == "{} run tests".format(sys.argv[0])
+
+    def test_missing_command_config_is_reported(self, monkeypatch):
+        monkeypatch.delenv("QA_TEST_COMMAND", raising=False)
+        with pytest.raises(RuntimeError, match="QA_TEST_COMMAND not defined"):
+            QACheck()._get_command_from_config("QA_TEST_COMMAND")
+
+    def test_command_output_is_returned(self):
+        assert QACheck()._run_command("echo hi") == "hi"
+
+    def test_failed_command_is_turned_into_a_qa_error_with_its_output(self):
+        with pytest.raises(QAError) as error:
+            QACheck()._run_command("echo boom; exit 1")
+        assert error.value.output == "boom"
+
+    def test_base_check_has_no_implementation(self):
+        with pytest.raises(NotImplementedError):
+            QACheck()._run_check()
+
+    def test_cleanup_runs_after_a_successful_check(self):
+        check = RecordingQACheck()
+        check.run()
+        assert check.cleaned_up
+
+    def test_cleanup_runs_after_a_failed_check(self):
+        check = RecordingQACheck(error=QAError("failed"))
+        with pytest.raises(QAError):
+            check.run()
+        assert check.cleaned_up
+
+
+class TestChecks:
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("app/migrations/0001_migration.py", False),
+            ("app/migrations/__init__.py", False),
+            ("app/migrations/0001_initial.py", True),
+            ("app/models.py", False),
+        ],
+        ids=["correct name", "init", "wrong name", "outside migrations"],
+    )
+    def test_migration_filename_is_checked(self, path, expected):
+        check = MigrationFilenamesQACheck()
+        assert check._is_migration_file_with_wrong_name(path) is expected
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("locale/cs/LC_MESSAGES/django.po", True),
+            ("locale/cs/LC_MESSAGES/django.mo", False),
+            ("app/models.py", False),
+        ],
+    )
+    def test_translation_file_is_recognized(self, path, expected):
+        assert MissingTranslationsQACheck()._is_translation_file(path) is expected
+
+
+class TestQACheckRunner:
+
+    def test_all_checks_run_and_succeed(self, run_checks):
+        checks = (RecordingQACheck(), RecordingQACheck())
+        runner = run_checks(*checks)
+        assert runner.success
+        assert len(runner.results) == 2
+        assert all(check.cleaned_up for check in checks)
+
+    def test_failed_check_fails_the_whole_run(self, run_checks):
+        checks = (RecordingQACheck(error=QAError("failed", "boom")), RecordingQACheck())
+        with pytest.raises(ClickException, match="QA check failed!"):
+            run_checks(*checks)
+        assert checks[1].cleaned_up, "the remaining checks still run"
+
+    def test_dirty_repository_stops_the_run(self, monkeypatch):
+        check = RecordingQACheck()
+        monkeypatch.setattr(QACheckRunner, "_is_repo_clean", lambda self: False)
+        with pytest.raises(ClickException, match="requires repository to be clean"):
+            QACheckRunner(check).run()
+        assert not check.cleaned_up

--- a/tests/test_sh.py
+++ b/tests/test_sh.py
@@ -1,0 +1,76 @@
+import pytest
+from click.testing import CliRunner
+
+import developers_chamber.scripts.sh as sh_module
+from developers_chamber.scripts import cli
+from developers_chamber.scripts.sh import sh  # noqa: F401  registers the command
+
+
+@pytest.fixture
+def run_sh(monkeypatch):
+    """Runs the sh command and returns what it would hand over to the shell."""
+    commands = []
+    monkeypatch.setattr(
+        sh_module, "call_command", lambda command, **kwargs: commands.append(command)
+    )
+
+    def run(*args):
+        result = CliRunner().invoke(cli, ["sh", *args], standalone_mode=False)
+        if result.exit_code:
+            raise AssertionError(result.output.strip() or repr(result.exception))
+        return commands[-1]
+
+    return run
+
+
+def test_quoted_command_is_passed_as_it_is(run_sh):
+    assert run_sh("python script.py") == "python script.py"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python a.py && python b.py",
+        "python a.py; python b.py",
+        "python a.py | tee log.txt",
+        "python a.py > log.txt",
+    ],
+    ids=["and", "semicolon", "pipe", "redirect"],
+)
+def test_shell_operators_of_a_quoted_command_are_kept(run_sh, command):
+    assert run_sh(command) == command
+
+
+def test_rest_of_the_command_line_is_joined_back(run_sh):
+    assert run_sh("python", "script.py") == "python script.py"
+
+
+def test_options_of_the_command_are_not_parsed_by_pydev(run_sh):
+    assert (
+        run_sh("python", "manage.py", "migrate", "--no-input")
+        == "python manage.py migrate --no-input"
+    )
+
+
+def test_quoting_of_the_joined_arguments_is_kept(run_sh):
+    assert run_sh("python", "-c", "print('x')") == "python -c 'print('\"'\"'x'\"'\"')'"
+
+
+def test_argument_with_a_space_stays_one_argument(run_sh):
+    assert run_sh("grep", "a b", "file.txt") == "grep 'a b' file.txt"
+
+
+def test_shell_operator_given_as_its_own_argument_stays_a_plain_argument(run_sh):
+    # a shell operator is only an operator inside a quoted command, several arguments are an
+    # argument vector where it has no special meaning
+    assert run_sh("echo", "a;", "echo", "b") == "echo 'a;' echo b"
+
+
+def test_missing_command_is_reported(monkeypatch):
+    commands = []
+    monkeypatch.setattr(
+        sh_module, "call_command", lambda command, **kwargs: commands.append(command)
+    )
+    result = CliRunner().invoke(cli, ["sh"], standalone_mode=False)
+    assert result.exit_code != 0
+    assert commands == []

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,85 @@
+from datetime import timedelta
+
+import click
+import pytest
+
+from developers_chamber.types import (
+    EnumType,
+    PreReleaseType,
+    ReleaseType,
+    TimedeltaType,
+    VersionFileType,
+)
+
+
+def convert_timedelta(value):
+    return TimedeltaType().convert(value, None, None)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2", timedelta(hours=2)),
+        ("30s", timedelta(seconds=30)),
+        ("15m", timedelta(minutes=15)),
+        ("3h", timedelta(hours=3)),
+        ("1d", timedelta(hours=8)),
+        ("1h30m", timedelta(hours=1, minutes=30)),
+        (" 1h 30m ", timedelta(hours=1, minutes=30)),
+    ],
+    ids=[
+        "hours by default",
+        "seconds",
+        "minutes",
+        "hours",
+        "working day",
+        "sum",
+        "whitespace",
+    ],
+)
+def test_time_delta_is_parsed(value, expected):
+    assert convert_timedelta(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("30m2", timedelta(minutes=30, hours=2)), ("1h30", timedelta(hours=31))],
+)
+def test_trailing_number_is_added_to_the_preceding_units(value, expected):
+    # a trailing number has no unit of its own and falls back to hours
+    assert convert_timedelta(value) == expected
+
+
+def test_unknown_unit_is_rejected():
+    with pytest.raises(click.UsageError, match="Invalid time delta"):
+        convert_timedelta("5x")
+
+
+def test_enum_name_is_converted_to_the_member():
+    assert EnumType(ReleaseType).convert("minor", None, None) is ReleaseType.minor
+
+
+def test_unknown_enum_name_is_rejected():
+    with pytest.raises(click.UsageError):
+        EnumType(ReleaseType).convert("revision", None, None)
+
+
+def test_enum_choices_are_the_members():
+    assert list(EnumType(PreReleaseType).choices) == ["alpha", "beta", "rc"]
+
+
+@pytest.mark.parametrize(
+    ("member", "expected"),
+    [
+        (ReleaseType.build, "build"),
+        (PreReleaseType.rc, "rc"),
+        (VersionFileType.npm, "npm"),
+    ],
+)
+def test_enum_is_rendered_as_its_value(member, expected):
+    assert str(member) == expected
+
+
+def test_version_file_type_compares_to_its_value():
+    # the file type is resolved from a file extension, therefore it has to be a string
+    assert VersionFileType.toml == "toml"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+import pytest
+from click import ClickException
+
+from developers_chamber.utils import call_command, pretty_time_delta, remove_ansi
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (45, "45s"),
+        (125, "2m 5s"),
+        (3725, "1h 2m 5s"),
+        (0, "0s"),
+        (-125, "2m 5s"),
+        (45.9, "45s"),
+    ],
+    ids=["seconds", "minutes", "hours", "zero", "negative", "fraction"],
+)
+def test_time_delta_is_rendered(seconds, expected):
+    assert pretty_time_delta(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("\x1b[31mfailed\x1b[0m", "failed"),
+        ("failed", "failed"),
+        ("\x1b[31ma\nb\x1b[0m", "a\nb"),
+    ],
+    ids=["color sequence", "plain text", "newlines kept"],
+)
+def test_ansi_is_removed(value, expected):
+    assert remove_ansi(value) == expected
+
+
+def test_successful_command_returns():
+    assert call_command("exit 0", quiet=True) is None
+
+
+def test_failed_command_is_reported():
+    with pytest.raises(ClickException, match="Command returned error"):
+        call_command("exit 1", quiet=True)
+
+
+def test_command_given_as_a_list_is_run_without_a_shell():
+    assert call_command(["true"], quiet=True) is None
+
+
+def test_environment_is_passed_to_the_command():
+    assert (
+        call_command('[ "$PYDEV_TEST" = "1" ]', quiet=True, env={"PYDEV_TEST": "1"})
+        is None
+    )
+
+
+def test_command_without_the_environment_does_not_see_it():
+    with pytest.raises(ClickException):
+        call_command('[ "$PYDEV_TEST" = "1" ]', quiet=True)

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -1,0 +1,321 @@
+import json
+
+import pytest
+import toml
+from click import BadParameter
+
+from developers_chamber.types import PreReleaseType, ReleaseType, VersionFileType
+from developers_chamber.version_utils import (
+    InvalidVersion,
+    Version,
+    _resolve_file_type,
+    bump_to_next_version,
+    bump_version,
+    get_next_version,
+    get_version,
+    get_version_files,
+    read_version_from_pom,
+)
+
+POM = """<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <artifactId>example</artifactId>
+  <version>{}</version>
+</project>
+"""
+
+
+class TestVersion:
+
+    def test_full_version_is_parsed(self):
+        version = Version("1.2.3")
+        assert (version.major, version.minor, version.patch) == (1, 2, 3)
+        assert version.pre_release is None
+        assert version.build is None
+
+    def test_missing_patch_defaults_to_zero(self):
+        assert str(Version("1.2")) == "1.2.0"
+
+    def test_pre_release_is_parsed(self):
+        version = Version("1.2.3-beta.4")
+        assert (version.pre_release, version.pre_release_num) == ("beta", 4)
+        assert version.build is None
+
+    def test_build_is_parsed(self):
+        version = Version("1.2.3-abc12")
+        assert version.build == "abc12"
+        assert version.pre_release is None
+
+    def test_pre_release_without_a_number_is_a_build(self):
+        # the pre-release alternative of the pattern requires the number, so a bare stage name
+        # falls through to the build alternative
+        version = Version("1.2.3-beta")
+        assert version.build == "beta"
+        assert version.pre_release is None
+
+    @pytest.mark.parametrize("version_str", ["1.2.3", "1.2.3-beta.4", "1.2.3-abc12"])
+    def test_version_is_rendered_back_to_the_same_string(self, version_str):
+        assert str(Version(version_str)) == version_str
+
+    @pytest.mark.parametrize(
+        "version_str", ["", "1", "1.2.3.4", "v1.2.3", "1.2.3-beta.x"]
+    )
+    def test_invalid_version_is_rejected(self, version_str):
+        with pytest.raises(InvalidVersion):
+            Version(version_str)
+
+    def test_replace_changes_only_the_given_parts(self):
+        assert str(Version("1.2.3").replace(minor=5)) == "1.5.3"
+
+    def test_replace_rejects_an_unknown_part(self):
+        with pytest.raises(AssertionError):
+            Version("1.2.3").replace(revision=1)
+
+
+class TestResolveFileType:
+
+    def test_explicit_file_type_wins(self):
+        assert _resolve_file_type(VersionFileType.npm, ".json") is VersionFileType.npm
+
+    def test_file_type_is_detected_from_the_extension(self):
+        assert _resolve_file_type(None, ".toml") == "toml"
+
+    def test_file_without_an_extension_is_a_text_file(self):
+        assert _resolve_file_type(None, "") is VersionFileType.text
+
+
+class TestGetVersion:
+
+    @pytest.mark.parametrize(
+        ("name", "content"),
+        [
+            ("version.json", json.dumps({"version": "1.2.3"})),
+            ("pyproject.toml", toml.dumps({"project": {"version": "1.2.3"}})),
+            ("VERSION", "1.2.3\n"),
+            ("pom.xml", POM.format("1.2.3")),
+        ],
+        ids=["json", "toml", "text without an extension", "pom"],
+    )
+    def test_version_is_read(self, version_file, name, content):
+        version_file.write(name, content)
+        assert str(get_version(name)) == "1.2.3"
+
+    def test_missing_file_is_reported(self, project_dir):
+        with pytest.raises(BadParameter, match="was not found"):
+            get_version("version.json")
+
+
+class TestGetVersionFiles:
+
+    def test_only_the_file_itself_is_returned_by_default(self, project_dir):
+        assert get_version_files("version.json") == ["version.json"]
+
+    def test_existing_npm_lock_file_is_added(self, version_file):
+        version_file.write("package.json", "{}")
+        version_file.write("package-lock.json", "{}")
+        assert get_version_files("package.json", VersionFileType.npm) == [
+            "package.json",
+            "package-lock.json",
+        ]
+
+    def test_missing_npm_lock_file_is_left_out(self, version_file):
+        version_file.write("package.json", "{}")
+        assert get_version_files("package.json", VersionFileType.npm) == [
+            "package.json"
+        ]
+
+
+class TestBumpVersion:
+
+    def test_json_file_keeps_its_other_keys(self, version_file):
+        version_file.write(
+            "version.json", json.dumps({"name": "example", "version": "1.2.3"})
+        )
+        bump_version("2.0.0", ["version.json"])
+        assert json.loads((version_file.path / "version.json").read_text()) == {
+            "name": "example",
+            "version": "2.0.0",
+        }
+
+    def test_toml_file_is_bumped(self, version_file):
+        version_file.write(
+            "pyproject.toml", toml.dumps({"project": {"name": "e", "version": "1.2.3"}})
+        )
+        bump_version("2.0.0", ["pyproject.toml"])
+        assert toml.loads((version_file.path / "pyproject.toml").read_text())[
+            "project"
+        ] == {
+            "name": "e",
+            "version": "2.0.0",
+        }
+
+    def test_text_file_is_bumped(self, version_file):
+        version_file.write("VERSION", "1.2.3")
+        bump_version("2.0.0", ["VERSION"])
+        assert (version_file.path / "VERSION").read_text() == "2.0.0"
+
+    def test_pom_file_is_bumped(self, version_file):
+        version_file.write("pom.xml", POM.format("1.2.3"))
+        bump_version("2.0.0", ["pom.xml"])
+        assert read_version_from_pom() == "2.0.0"
+
+    def test_npm_file_is_bumped_together_with_its_lock_file(self, version_file):
+        version_file.write_version("1.2.3", "package.json")
+        version_file.write(
+            "package-lock.json",
+            json.dumps({"version": "1.2.3", "packages": {"": {"version": "1.2.3"}}}),
+        )
+        bump_version("2.0.0", ["package.json"], VersionFileType.npm)
+        assert version_file.read_version("package.json") == "2.0.0"
+        lock_data = json.loads((version_file.path / "package-lock.json").read_text())
+        assert lock_data["version"] == "2.0.0"
+        assert lock_data["packages"][""]["version"] == "2.0.0"
+
+    def test_missing_npm_lock_file_is_reported(self, version_file):
+        version_file.write_version("1.2.3", "package.json")
+        with pytest.raises(BadParameter, match="Lock file .* was not found"):
+            bump_version("2.0.0", ["package.json"], VersionFileType.npm)
+
+    def test_all_given_files_are_bumped(self, version_file):
+        version_file.write_version("1.2.3")
+        version_file.write("VERSION", "1.2.3")
+        bump_version("2.0.0", ["version.json", "VERSION"])
+        assert version_file.read_version() == "2.0.0"
+        assert (version_file.path / "VERSION").read_text() == "2.0.0"
+
+    def test_missing_file_is_reported(self, project_dir):
+        with pytest.raises(BadParameter, match="was not found"):
+            bump_version("2.0.0", ["version.json"])
+
+    def test_no_files_is_reported(self, project_dir):
+        with pytest.raises(BadParameter, match="Given no files"):
+            bump_version("2.0.0", [])
+
+
+class TestGetNextVersion:
+
+    @pytest.fixture
+    def next_version(self, version_file):
+        def get(current, **kwargs):
+            version_file.write_version(current)
+            return str(get_next_version(file="version.json", **kwargs))
+
+        return get
+
+    @pytest.mark.parametrize(
+        ("current", "kwargs", "expected"),
+        [
+            ("1.2.3", {"release_type": ReleaseType.patch}, "1.2.4"),
+            ("1.2.3", {"release_type": ReleaseType.minor}, "1.3.0"),
+            ("1.2.3", {"release_type": ReleaseType.major}, "2.0.0"),
+            ("1.2.3", {}, "2.0.0"),
+            ("1.2.3-beta.4", {"release_type": ReleaseType.patch}, "1.2.4"),
+            ("1.2.3-beta.4", {"release_type": ReleaseType.release}, "1.2.3"),
+            (
+                "1.2.3",
+                {"release_type": ReleaseType.build, "build_hash": "abcdef123456"},
+                "1.2.3-abcde",
+            ),
+        ],
+        ids=[
+            "patch",
+            "minor resets the patch",
+            "major resets the rest",
+            "no release type bumps the major",
+            "bump drops the pre-release",
+            "release only drops the pre-release",
+            "build hash is shortened",
+        ],
+    )
+    def test_version_is_bumped(self, next_version, current, kwargs, expected):
+        assert next_version(current, **kwargs) == expected
+
+    def test_build_without_a_hash_is_reported(self, next_version):
+        with pytest.raises(BadParameter, match="Build hash is required"):
+            next_version("1.2.3", release_type=ReleaseType.build)
+
+    @pytest.mark.parametrize(
+        ("current", "kwargs", "expected"),
+        [
+            ("1.2.3-alpha.1", {"pre_release": PreReleaseType.alpha}, "1.2.3-alpha.2"),
+            ("1.2.3-alpha.2", {"pre_release": PreReleaseType.beta}, "1.2.3-beta.1"),
+            (
+                "1.2.3",
+                {
+                    "release_type": ReleaseType.minor,
+                    "pre_release": PreReleaseType.alpha,
+                },
+                "1.3.0-alpha.1",
+            ),
+            (
+                "1.2.3",
+                {"release_type": ReleaseType.major, "pre_release": PreReleaseType.beta},
+                "2.0.0-beta.1",
+            ),
+        ],
+        ids=[
+            "same stage increments its number",
+            "higher stage starts from one",
+            "minor release starts a new pre-release",
+            "major release starts a new pre-release",
+        ],
+    )
+    def test_pre_release_is_bumped(self, next_version, current, kwargs, expected):
+        assert next_version(current, **kwargs) == expected
+
+    @pytest.mark.parametrize(
+        ("current", "kwargs", "message"),
+        [
+            (
+                "1.2.3-rc.1",
+                {"pre_release": PreReleaseType.alpha},
+                "Cannot downgrade pre-release stage",
+            ),
+            (
+                "1.2.3",
+                {"pre_release": PreReleaseType.alpha},
+                "without specifying --release-type",
+            ),
+            (
+                "1.2.3-alpha.1",
+                {
+                    "release_type": ReleaseType.patch,
+                    "pre_release": PreReleaseType.alpha,
+                },
+                "not allowed for patch releases",
+            ),
+        ],
+        ids=["downgrade", "stable version without a release type", "patch release"],
+    )
+    def test_invalid_pre_release_is_reported(
+        self, next_version, current, kwargs, message
+    ):
+        with pytest.raises(BadParameter, match=message):
+            next_version(current, **kwargs)
+
+
+class TestBumpToNextVersion:
+
+    def test_next_version_is_written_to_all_files(self, version_file):
+        version_file.write_version("1.2.3")
+        version_file.write("VERSION", "1.2.3")
+        bump_to_next_version(
+            release_type=ReleaseType.minor, files=["version.json", "VERSION"]
+        )
+        assert version_file.read_version() == "1.3.0"
+        assert (version_file.path / "VERSION").read_text() == "1.3.0"
+
+    def test_no_files_is_reported(self, project_dir):
+        with pytest.raises(BadParameter, match="Given no files"):
+            bump_to_next_version(release_type=ReleaseType.minor, files=[])
+
+
+class TestReadVersionFromPom:
+
+    def test_version_is_read(self, version_file):
+        version_file.write("pom.xml", POM.format("1.2.3"))
+        assert read_version_from_pom() == "1.2.3"
+
+    def test_missing_file_is_reported(self, project_dir):
+        with pytest.raises(BadParameter, match="was not found"):
+            read_version_from_pom()


### PR DESCRIPTION
- Add developers_chamber/config.py which loads the .pydev configuration and flattens structured (YAML/JSON) settings into the environment variables the commands read: nested objects become underscore-joined sections, lists are joined with a comma and null values are skipped
- Keep the original .conf dotenv format working; formats can be mixed in one directory and files are applied in alphabetical order, home config first and project config second
- Report invalid config files through a new ConfigError, which pydev.py prints to stderr and exits with code 1 instead of failing with a traceback
- Add encoders for settings with their own format (ALIASES, PROJECT_DOCKER_COMPOSE_CONTAINERS_DIR_TO_COPY, ..._INSTALL_COMMAND, ..._ENV); each also accepts the plain string notation
- Refactor click param types: extract SeparatedFieldsType so parsing and encoding are derived from one separator/field declaration, and fix ContainerEnvironment to split each variable on the first "=" only and fail on a missing assignment
- Add tests for config, options, aliases, types, utils, git utils, qa and version utils
- Add a GitHub Actions workflow running the tests on Python 3.10-3.13
- Document the new formats in README.md, add example/.pydev/base.yaml and extend .gitignore