### PR TITLE
FixReleaseCommand: allow releasing from the checked out release branch

### DIFF
--- a/developers_chamber/git_utils.py
+++ b/developers_chamber/git_utils.py
@@ -62,7 +62,14 @@ def create_release_branch(
         release_branch_name = _release_branch_name(version, release_prefix)
     else:
         raise BadParameter("build is not allowed for release")
-    g.checkout(branch_name or "HEAD", b=release_branch_name)
+
+    # The release branch may already be the checked out one (CI runs the release from it);
+    # git refuses to create it again and standing on it is all that is needed.
+    is_on_release_branch = (
+        not repo.head.is_detached and repo.active_branch.name == release_branch_name
+    )
+    if not is_on_release_branch:
+        g.checkout(branch_name or "HEAD", b=release_branch_name)
 
     if remote_name:
         g.push(remote_name, release_branch_name, force=True)
@@ -113,15 +120,22 @@ def create_release(
 
     release_tag_name = _release_tag_name(version, release_prefix)
 
+    # A patch release is usually built from the release branch itself (CI checks it out), so
+    # the branch can be neither deleted nor recreated - the bump commit goes on top of it.
+    is_on_release_branch = (
+        not repo.head.is_detached and repo.active_branch.name == release_branch_name
+    )
+
     branch_names = [branch.name for branch in repo.branches]
-    if release_branch_name in branch_names:
+    if release_branch_name in branch_names and not is_on_release_branch:
         g.branch("-D", release_branch_name)
 
     tags = [tag.name for tag in repo.tags]
     if release_tag_name in tags:
         g.tag("-d", release_tag_name)
 
-    g.checkout(branch_name or "HEAD", b=release_branch_name)
+    if not is_on_release_branch:
+        g.checkout(branch_name or "HEAD", b=release_branch_name)
     g.commit(message=f"Bump version to '{version}'")
 
     g.tag(release_tag_name)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="developers-chamber",
-    version="1.0.0",
+    version="1.0.1",
     description="A small plugin which help with development, deployment, git",
     keywords="django, skripts, easy live, git, bitbucket, Jira",
     author="Druids team",

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -12,12 +12,15 @@ from developers_chamber.git_utils import (  # noqa: E402
     commit_version,
     create_branch,
     create_deployment_branch,
+    create_release,
+    create_release_branch,
     get_commit_hash,
     get_current_branch_name,
     get_current_issue_key,
     get_remote_path,
     get_remote_url,
 )
+from developers_chamber.types import ReleaseType  # noqa: E402
 from developers_chamber.version_utils import Version  # noqa: E402
 
 pytestmark = pytest.mark.usefixtures("git_repo")
@@ -126,6 +129,47 @@ class TestBumpVersionFromReleaseTag:
         git_repo.create_tag("nightly")
         with pytest.raises(UsageError, match="Invalid release branch"):
             bump_version_from_release_tag()
+
+
+class TestCreateReleaseBranch:
+
+    def test_branch_is_created_from_the_current_branch(self, git_repo):
+        assert (
+            create_release_branch(Version("1.3.0"), ReleaseType.minor) == "release/v1.3"
+        )
+        assert git_repo.active_branch.name == "release/v1.3"
+
+    def test_checked_out_release_branch_is_kept(self, git_repo):
+        """The branch cannot be created again while the worktree stands on it."""
+        git_repo.git.checkout("HEAD", b="release/v1.2")
+        assert (
+            create_release_branch(Version("1.2.4"), ReleaseType.patch) == "release/v1.2"
+        )
+        assert git_repo.active_branch.name == "release/v1.2"
+
+
+class TestCreateRelease:
+
+    def test_release_branch_is_created_from_the_current_branch(self, git_repo):
+        assert create_release("version.json", ReleaseType.minor) == "release/v1.3"
+        assert git_repo.active_branch.name == "release/v1.3"
+        assert git_repo.head.commit.message.strip() == "Bump version to '1.3.0'"
+        assert "1.3.0" in [tag.name for tag in git_repo.tags]
+
+    def test_existing_release_branch_is_replaced(self, git_repo):
+        git_repo.git.branch("release/v1.3")
+        assert create_release("version.json", ReleaseType.minor) == "release/v1.3"
+        assert git_repo.head.commit.message.strip() == "Bump version to '1.3.0'"
+
+    def test_release_is_committed_on_top_of_the_checked_out_release_branch(
+        self, git_repo
+    ):
+        """The release branch cannot be deleted while the worktree stands on it."""
+        git_repo.git.checkout("HEAD", b="release/v1.2")
+        assert create_release("version.json", ReleaseType.patch) == "release/v1.2"
+        assert git_repo.active_branch.name == "release/v1.2"
+        assert git_repo.head.commit.message.strip() == "Bump version to '1.2.4'"
+        assert "1.2.4" in [tag.name for tag in git_repo.tags]
 
 
 class TestDeploymentBranch:


### PR DESCRIPTION
- create_release_branch: skip the checkout when the worktree already stands on the target release branch, since git refuses to create a branch that is currently checked out (CI runs the release directly from that branch)
- create_release: keep the release branch when it is the checked out one, so it is neither deleted nor recreated and the version bump commit is added on top of it
- add tests covering both commands: creating the release branch from the current branch, replacing an existing release branch, and releasing from the already checked out release branch
- bump version to 1.0.1