### PR TITLE
ReleaseGitlab: add gitlab create-release-record command

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,34 @@ The `create-release` and `create-release-branch` commands accept `--release-pref
 Helpers for GitLab management.
 
 #### Commands
-* `pydev git create-release-merge-request` - create a new merge request in a GitLab project. It is often used after the project release
+* `pydev gitlab create-release-merge-request` - create a new merge request from the current branch in a GitLab project. It is often used after the project release
+* `pydev gitlab create-merge-request` - create a new merge request with the given title, optionally with automerge and removal of the source branch
+* `pydev gitlab activate-merge-request-automerge` - merge an existing merge request as soon as its pipeline succeeds
+* `pydev gitlab run-job` - run a pipeline of the selected branch, optionally with variables (`--variables "A=1,B=2"`)
+* `pydev gitlab get-project-id` - print the numeric ID of the GitLab project
+* `pydev gitlab create-release-record` - create a GitLab release object for an already existing release tag
+
+The `create-release-record` command hangs a [GitLab release](https://docs.gitlab.com/user/project/releases/) on a tag created by `pydev git create-release`. The tag stays the source of truth for publishing, the release is metadata on top of it, so that "what is released" is readable per project and across the group:
+
+```bash
+pydev gitlab create-release-record --tag-name "$CI_COMMIT_TAG" \
+    --description "$(sed -n '/^## \[1.3.0\]/,/^## /p' CHANGELOG.md)" \
+    --asset "Wheel=https://pypi.example.com/pkg-1.3.0.whl"
+```
+
+* the release name defaults to the tag with the monorepo prefix separated by a space (`lib-a@1.3.0` -> `lib-a 1.3.0`), `--name` overrides it
+* `--description` is passed in by the caller, usually as the `CHANGELOG.md` section of the released version
+* `--asset "name=URL"` can be repeated for every published artifact (package in the registry, image tag)
+* in a CI job neither a token nor a project has to be set up: `CI_JOB_TOKEN` and `CI_COMMIT_TAG` are read from the environment and `--project` accepts the numeric `$CI_PROJECT_ID`. Only `--url` has to be passed as `$CI_SERVER_URL` when `GITLAB_API_URL` is not set
+* a request rejected by GitLab (an already existing release among them) ends the command with an error. A release is an addition, not a critical path, so let the release job keep going with `|| true`
 
 #### Configuration
 * `GITLAB_API_URL` - URL to gitlab API service
 * `GITLAB_PROJECT` - GitLab project name
 * `GITLAB_TARGET_BRANCH` - target branch for the merge request
-* `GITLAB_TOKEN` - GitLab authentication token
+* `GITLAB_TOKEN` - GitLab authentication token, sent as the `PRIVATE-TOKEN` header
+* `CI_JOB_TOKEN` - CI job token of the running job, sent as the `JOB-TOKEN` header and preferred over `GITLAB_TOKEN`. Accepted by `create-release-record` only, because the endpoints of the other commands do not take a job token
+* `CI_COMMIT_TAG` - tag of the release for the `create-release-record` command
 
 ### QA
 

--- a/developers_chamber/gitlab_utils.py
+++ b/developers_chamber/gitlab_utils.py
@@ -6,6 +6,18 @@ from click import UsageError
 from urllib.parse import quote
 
 
+def _auth_headers(token=None, job_token=None):
+    """
+    A CI job token is accepted only by a part of the API (the Releases endpoints among them),
+    so it is used when it is available and the private token stays the fallback.
+    """
+    if job_token:
+        return {"JOB-TOKEN": job_token}
+    if token:
+        return {"PRIVATE-TOKEN": token}
+    raise UsageError("GitLab token or job token is required")
+
+
 def create_merge_request(
     url,
     token,
@@ -20,9 +32,7 @@ def create_merge_request(
 ):
     response = requests.post(
         f"{url}/api/v4/projects/{quote_plus(project)}/merge_requests",
-        headers={
-            "PRIVATE-TOKEN": token,
-        },
+        headers=_auth_headers(token),
         json={
             "source_branch": source_branch,
             "target_branch": target_branch,
@@ -48,9 +58,7 @@ def activate_automerge(url, token, project, merge_request_id, retries=5):
         merge_response = requests.put(
             f"{url}/api/v4/projects/{quote_plus(project)}/merge_requests/{merge_request_id}/merge",
             json={"merge_when_pipeline_succeeds": True},
-            headers={
-                "PRIVATE-TOKEN": token,
-            },
+            headers=_auth_headers(token),
         )
         if merge_response.status_code == 200:
             return "Automerge activated"
@@ -61,9 +69,7 @@ def activate_automerge(url, token, project, merge_request_id, retries=5):
 def run_job(url, token, project, ref, variables):
     response = requests.post(
         f"{url}/api/v4/projects/{quote_plus(project)}/pipeline",
-        headers={
-            "PRIVATE-TOKEN": token,
-        },
+        headers=_auth_headers(token),
         json={
             "ref": ref,
             "variables": [
@@ -86,7 +92,7 @@ def get_project_id(url, project, token):
     response = requests.get(
         f"{url}/api/v4/projects/{quote_plus(project)}",
         headers={
-            "PRIVATE-TOKEN": token,
+            **_auth_headers(token),
             "Content-type": "application/json",
         },
     )
@@ -94,3 +100,55 @@ def get_project_id(url, project, token):
         raise UsageError(f'GitLab error: {response.content.decode("utf-8")}')
     else:
         return response.json()["id"]
+
+
+def _release_record_name(tag_name):
+    """
+    The release is named after its tag, so a monorepo release page reads as a changelog feed:
+    "lib-a@1.3.0" -> "lib-a 1.3.0", a tag without a prefix stays as it is.
+    """
+    return tag_name.replace("@", " ", 1)
+
+
+def parse_asset_links(assets):
+    """Turn the "name=URL" options into the assets links of the Releases API."""
+    links = []
+    for asset in assets:
+        # The URL may carry a query string, so only the first "=" separates the name.
+        name, _, url = asset.partition("=")
+        if not name or not url:
+            raise UsageError(
+                f'Invalid asset "{asset}", the expected format is "name=URL"'
+            )
+        links.append({"name": name, "url": url})
+    return links
+
+
+def create_release_record(
+    url,
+    project,
+    tag_name,
+    name=None,
+    description=None,
+    asset_links=None,
+    token=None,
+    job_token=None,
+):
+    data = {
+        "tag_name": tag_name,
+        "name": name or _release_record_name(tag_name),
+    }
+    if description:
+        data["description"] = description
+    if asset_links:
+        data["assets"] = {"links": list(asset_links)}
+
+    response = requests.post(
+        f"{url}/api/v4/projects/{quote_plus(project)}/releases",
+        headers=_auth_headers(token, job_token),
+        json=data,
+    )
+    if response.status_code != 201:
+        raise UsageError(f'GitLab error: {response.content.decode("utf-8")}')
+    else:
+        return response.json().get("_links", {}).get("self") or tag_name

--- a/developers_chamber/scripts/gitlab.py
+++ b/developers_chamber/scripts/gitlab.py
@@ -7,9 +7,12 @@ from developers_chamber.gitlab_utils import (
     activate_automerge as activate_automerge_func,
     run_job as run_job_func,
     get_project_id as get_project_id_func,
+    create_release_record as create_release_record_func,
+    parse_asset_links,
 )
 from developers_chamber.scripts import cli
 from developers_chamber.git_utils import get_remote_url, get_remote_path
+
 
 def _default_gitlab_url():
     """Without its own setting the web url is the api url without the /api/v4 suffix."""
@@ -308,3 +311,87 @@ def get_project_id(url, project, token):
         project = get_remote_path()
 
     click.echo(get_project_id_func(url, project, token))
+
+
+@gitlab.command()
+@click.option(
+    "--url",
+    help="GitLab instance API URL (defaults to gitlab.com)",
+    type=str,
+    required=False,
+    envvar="GITLAB_URL",
+    default=_default_gitlab_url,
+)
+@click.option(
+    "--token",
+    help="token (can be set as env variable GITLAB_TOKEN)",
+    type=str,
+    required=False,
+    envvar="GITLAB_TOKEN",
+)
+@click.option(
+    "--job-token",
+    help="CI job token, preferred over the private token (can be set as env variable "
+    "CI_JOB_TOKEN)",
+    type=str,
+    required=False,
+    envvar="CI_JOB_TOKEN",
+)
+@click.option(
+    "--project",
+    help="GitLab project name or ID (defaults to env variable GITLAB_PROJECT)",
+    type=str,
+    required=False,
+    envvar="GITLAB_PROJECT",
+)
+@click.option(
+    "--tag-name",
+    help="name of the already pushed release tag (defaults to env variable CI_COMMIT_TAG)",
+    type=str,
+    required=True,
+    envvar="CI_COMMIT_TAG",
+)
+@click.option(
+    "--name",
+    help='release name (defaults to the tag name, e.g. "lib-a@1.3.0" -> "lib-a 1.3.0")',
+    type=str,
+    required=False,
+)
+@click.option(
+    "--description",
+    help="release description, usually the CHANGELOG.md section of the released version",
+    type=str,
+    required=False,
+)
+@click.option(
+    "--asset",
+    "assets",
+    help='link to a published artifact in the "name=URL" format (can be used repeatedly)',
+    type=str,
+    multiple=True,
+)
+def create_release_record(
+    url, token, job_token, project, tag_name, name, description, assets
+):
+    """
+    Create a GitLab release object for an already existing release tag.
+    """
+    if not token and not job_token:
+        raise click.UsageError("GitLab token or job token is required")
+    if not url:
+        url = get_remote_url()
+    if not project:
+        project = get_remote_path()
+
+    release_url = create_release_record_func(
+        url=url,
+        project=project,
+        tag_name=tag_name,
+        name=name,
+        description=description,
+        asset_links=parse_asset_links(assets),
+        token=token,
+        job_token=job_token,
+    )
+
+    click.echo(f"Release record was successfully created: {release_url}")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="developers-chamber",
-    version="1.0.1",
+    version="1.0.2",
     description="A small plugin which help with development, deployment, git",
     keywords="django, skripts, easy live, git, bitbucket, Jira",
     author="Druids team",

--- a/tests/test_gitlab_script.py
+++ b/tests/test_gitlab_script.py
@@ -1,0 +1,209 @@
+import pytest
+from click.testing import CliRunner
+
+pytest.importorskip("git", reason='requires the "gitlab" extra')
+
+from developers_chamber.scripts import gitlab as gitlab_script  # noqa: E402
+
+AMBIENT_ENVVARS = (
+    "GITLAB_URL",
+    "GITLAB_API_URL",
+    "GITLAB_TOKEN",
+    "GITLAB_PROJECT",
+    "CI_JOB_TOKEN",
+    "CI_COMMIT_TAG",
+)
+
+
+@pytest.fixture
+def create_release_record(monkeypatch):
+    """Catch what the command hands over to the API call."""
+
+    calls = []
+
+    def fake_create_release_record(**kwargs):
+        calls.append(kwargs)
+        return "https://gitlab.example.com/g/p/-/releases/1.3.0"
+
+    fake_create_release_record.calls = calls
+    monkeypatch.setattr(
+        gitlab_script, "create_release_record_func", fake_create_release_record
+    )
+    return fake_create_release_record
+
+
+def run(args, env=None):
+    return CliRunner().invoke(
+        gitlab_script.create_release_record,
+        args,
+        # The variables of the developer environment must not decide the result of a test.
+        env={**{name: None for name in AMBIENT_ENVVARS}, **(env or {})},
+    )
+
+
+class TestCreateReleaseRecordCommand:
+    def test_tag_name_is_required(self, create_release_record):
+        result = run(["--url", "https://gitlab.example.com", "--token", "secret"])
+
+        assert result.exit_code != 0
+        assert "--tag-name" in result.output
+
+    def test_a_token_is_required(self, create_release_record):
+        result = run(
+            [
+                "--url",
+                "https://gitlab.example.com",
+                "--project",
+                "group/project",
+                "--tag-name",
+                "1.3.0",
+            ]
+        )
+
+        assert result.exit_code != 0
+        assert "token" in result.output
+
+    def test_release_is_created_from_the_options(self, create_release_record):
+        result = run(
+            [
+                "--url",
+                "https://gitlab.example.com",
+                "--project",
+                "group/project",
+                "--token",
+                "secret",
+                "--tag-name",
+                "lib-a@1.3.0",
+                "--description",
+                "### Added\n- a thing",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert create_release_record.calls[0] == {
+            "url": "https://gitlab.example.com",
+            "project": "group/project",
+            "tag_name": "lib-a@1.3.0",
+            "name": None,
+            "description": "### Added\n- a thing",
+            "asset_links": [],
+            "token": "secret",
+            "job_token": None,
+        }
+
+    def test_job_token_is_taken_from_the_ci_environment(self, create_release_record):
+        result = run(
+            [
+                "--url",
+                "https://gitlab.example.com",
+                "--project",
+                "group/project",
+                "--tag-name",
+                "1.3.0",
+            ],
+            env={"CI_JOB_TOKEN": "ci-secret"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert create_release_record.calls[0]["job_token"] == "ci-secret"
+
+    def test_tag_name_is_taken_from_the_ci_environment(self, create_release_record):
+        result = run(
+            [
+                "--url",
+                "https://gitlab.example.com",
+                "--project",
+                "group/project",
+                "--token",
+                "secret",
+            ],
+            env={"CI_COMMIT_TAG": "lib-a@1.3.0"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert create_release_record.calls[0]["tag_name"] == "lib-a@1.3.0"
+
+    def test_assets_are_repeatable(self, create_release_record):
+        result = run(
+            [
+                "--url",
+                "https://gitlab.example.com",
+                "--project",
+                "group/project",
+                "--token",
+                "secret",
+                "--tag-name",
+                "1.3.0",
+                "--asset",
+                "Wheel=https://pypi.example.com/pkg.whl",
+                "--asset",
+                "Image=https://reg.example.com/i?tag=1.3.0",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert create_release_record.calls[0]["asset_links"] == [
+            {"name": "Wheel", "url": "https://pypi.example.com/pkg.whl"},
+            {"name": "Image", "url": "https://reg.example.com/i?tag=1.3.0"},
+        ]
+
+    def test_malformed_asset_stops_the_command(self, create_release_record):
+        result = run(
+            [
+                "--url",
+                "https://gitlab.example.com",
+                "--project",
+                "group/project",
+                "--token",
+                "secret",
+                "--tag-name",
+                "1.3.0",
+                "--asset",
+                "https://pypi.example.com/pkg.whl",
+            ]
+        )
+
+        assert result.exit_code != 0
+        assert "name=URL" in result.output
+        assert create_release_record.calls == []
+
+    def test_project_falls_back_to_the_git_remote(
+        self, create_release_record, monkeypatch
+    ):
+        monkeypatch.setattr(
+            gitlab_script, "get_remote_path", lambda: "group/from-remote"
+        )
+
+        result = run(
+            [
+                "--url",
+                "https://gitlab.example.com",
+                "--token",
+                "secret",
+                "--tag-name",
+                "1.3.0",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert create_release_record.calls[0]["project"] == "group/from-remote"
+
+    def test_created_release_is_reported(self, create_release_record):
+        result = run(
+            [
+                "--url",
+                "https://gitlab.example.com",
+                "--project",
+                "group/project",
+                "--token",
+                "secret",
+                "--tag-name",
+                "1.3.0",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            "Release record was successfully created: "
+            "https://gitlab.example.com/g/p/-/releases/1.3.0" in result.output
+        )

--- a/tests/test_gitlab_utils.py
+++ b/tests/test_gitlab_utils.py
@@ -1,0 +1,235 @@
+import pytest
+from click import UsageError
+
+from developers_chamber import gitlab_utils
+from developers_chamber.gitlab_utils import (
+    _auth_headers,
+    _release_record_name,
+    create_release_record,
+    parse_asset_links,
+)
+
+
+class TestAuthHeaders:
+    """The Releases API takes a job token, the rest of the API takes a private one."""
+
+    def test_private_token_is_sent_in_the_private_token_header(self):
+        assert _auth_headers(token="secret") == {"PRIVATE-TOKEN": "secret"}
+
+    def test_job_token_is_sent_in_the_job_token_header(self):
+        assert _auth_headers(job_token="ci-secret") == {"JOB-TOKEN": "ci-secret"}
+
+    def test_job_token_wins_over_the_private_one(self):
+        assert _auth_headers(token="secret", job_token="ci-secret") == {
+            "JOB-TOKEN": "ci-secret"
+        }
+
+    def test_missing_token_is_reported(self):
+        with pytest.raises(UsageError, match="token"):
+            _auth_headers()
+
+
+class TestReleaseRecordName:
+    """The release is named after its tag, the monorepo prefix included."""
+
+    def test_tag_without_a_prefix_is_the_name(self):
+        assert _release_record_name("1.3.0") == "1.3.0"
+
+    def test_prefix_is_separated_from_the_version_by_a_space(self):
+        assert _release_record_name("lib-a@1.3.0") == "lib-a 1.3.0"
+
+    def test_pre_release_tag_keeps_its_suffix(self):
+        assert _release_record_name("lib-a@1.3.0-beta.4") == "lib-a 1.3.0-beta.4"
+
+
+class TestParseAssetLinks:
+    def test_no_asset_gives_no_link(self):
+        assert parse_asset_links(()) == []
+
+    def test_asset_is_split_into_a_name_and_a_url(self):
+        assert parse_asset_links(("Wheel=https://pypi.example.com/pkg.whl",)) == [
+            {"name": "Wheel", "url": "https://pypi.example.com/pkg.whl"}
+        ]
+
+    def test_assets_keep_their_order(self):
+        assert parse_asset_links(("a=https://x", "b=https://y")) == [
+            {"name": "a", "url": "https://x"},
+            {"name": "b", "url": "https://y"},
+        ]
+
+    def test_url_query_string_survives_the_split(self):
+        assert parse_asset_links(("Image=https://reg.example.com/i?tag=1.3.0",)) == [
+            {"name": "Image", "url": "https://reg.example.com/i?tag=1.3.0"}
+        ]
+
+    @pytest.mark.parametrize("asset", ["https://x", "=https://x", "name=", "name"])
+    def test_malformed_asset_is_reported(self, asset):
+        with pytest.raises(UsageError, match="name=URL"):
+            parse_asset_links((asset,))
+
+
+class FakeResponse:
+    def __init__(self, status_code=201, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.content = b'{"message": "error"}'
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def post(monkeypatch):
+    """Catch the request instead of sending it, and answer it with a created release."""
+
+    calls = []
+
+    def fake_post(url, headers=None, json=None):
+        calls.append({"url": url, "headers": headers, "json": json})
+        return fake_post.response
+
+    fake_post.response = FakeResponse(
+        payload={
+            "_links": {
+                "self": "https://gitlab.example.com/g/p/-/releases/lib-a%401.3.0"
+            }
+        }
+    )
+    fake_post.calls = calls
+    monkeypatch.setattr(gitlab_utils.requests, "post", fake_post)
+    return fake_post
+
+
+class TestCreateReleaseRecord:
+    def test_release_is_posted_to_the_project_releases_endpoint(self, post):
+        create_release_record(
+            url="https://gitlab.example.com",
+            project="group/project",
+            tag_name="1.3.0",
+            token="secret",
+        )
+
+        assert (
+            post.calls[0]["url"]
+            == "https://gitlab.example.com/api/v4/projects/group%2Fproject/releases"
+        )
+
+    def test_numeric_project_id_is_used_as_it_is(self, post):
+        create_release_record(
+            url="https://gitlab.example.com",
+            project="42",
+            tag_name="1.3.0",
+            token="secret",
+        )
+
+        assert post.calls[0]["url"].endswith("/projects/42/releases")
+
+    def test_job_token_is_used_for_the_call(self, post):
+        create_release_record(
+            url="https://gitlab.example.com",
+            project="group/project",
+            tag_name="1.3.0",
+            token="secret",
+            job_token="ci-secret",
+        )
+
+        assert post.calls[0]["headers"] == {"JOB-TOKEN": "ci-secret"}
+
+    def test_name_defaults_to_the_tag(self, post):
+        create_release_record(
+            url="https://gitlab.example.com",
+            project="group/project",
+            tag_name="lib-a@1.3.0",
+            token="secret",
+        )
+
+        assert post.calls[0]["json"] == {
+            "tag_name": "lib-a@1.3.0",
+            "name": "lib-a 1.3.0",
+        }
+
+    def test_given_name_and_description_are_sent(self, post):
+        create_release_record(
+            url="https://gitlab.example.com",
+            project="group/project",
+            tag_name="1.3.0",
+            name="Chamber 1.3.0",
+            description="### Added\n- a thing",
+            token="secret",
+        )
+
+        assert post.calls[0]["json"] == {
+            "tag_name": "1.3.0",
+            "name": "Chamber 1.3.0",
+            "description": "### Added\n- a thing",
+        }
+
+    def test_empty_description_is_left_out(self, post):
+        create_release_record(
+            url="https://gitlab.example.com",
+            project="group/project",
+            tag_name="1.3.0",
+            description="",
+            token="secret",
+        )
+
+        assert "description" not in post.calls[0]["json"]
+
+    def test_asset_links_are_sent_as_release_assets(self, post):
+        create_release_record(
+            url="https://gitlab.example.com",
+            project="group/project",
+            tag_name="1.3.0",
+            asset_links=[{"name": "Wheel", "url": "https://pypi.example.com/pkg.whl"}],
+            token="secret",
+        )
+
+        assert post.calls[0]["json"]["assets"] == {
+            "links": [{"name": "Wheel", "url": "https://pypi.example.com/pkg.whl"}]
+        }
+
+    def test_no_asset_link_leaves_the_assets_out(self, post):
+        create_release_record(
+            url="https://gitlab.example.com",
+            project="group/project",
+            tag_name="1.3.0",
+            asset_links=[],
+            token="secret",
+        )
+
+        assert "assets" not in post.calls[0]["json"]
+
+    def test_web_url_of_the_release_is_returned(self, post):
+        assert (
+            create_release_record(
+                url="https://gitlab.example.com",
+                project="group/project",
+                tag_name="lib-a@1.3.0",
+                token="secret",
+            )
+            == "https://gitlab.example.com/g/p/-/releases/lib-a%401.3.0"
+        )
+
+    def test_answer_without_a_link_falls_back_to_the_tag(self, post):
+        post.response = FakeResponse(payload={})
+
+        assert (
+            create_release_record(
+                url="https://gitlab.example.com",
+                project="group/project",
+                tag_name="lib-a@1.3.0",
+                token="secret",
+            )
+            == "lib-a@1.3.0"
+        )
+
+    def test_rejected_call_is_reported(self, post):
+        post.response = FakeResponse(status_code=409)
+
+        with pytest.raises(UsageError, match="GitLab error"):
+            create_release_record(
+                url="https://gitlab.example.com",
+                project="group/project",
+                tag_name="1.3.0",
+                token="secret",
+            )


### PR DESCRIPTION
- add `pydev gitlab create-release-record` creating a GitLab release object on an already pushed release tag, with an optional name, description and repeatable `--asset "name=URL"` links
- default the release name to the tag with the monorepo prefix separated by a space (`lib-a@1.3.0` -> `lib-a 1.3.0`)
- accept a CI job token (`CI_JOB_TOKEN`) and prefer it over the private token, so the command needs no extra setup in a release job; the tag defaults to `CI_COMMIT_TAG` and the project accepts a numeric ID
- extract the header building into `_auth_headers()` and reuse it in all GitLab calls; a missing token now ends with a clear usage error
- report a request rejected by GitLab as an error and echo the web URL of the created release, falling back to the tag name
- cover the new command and utils with tests (options, env fallbacks, asset parsing, request payload, error handling)
- document the command, its CI usage and the new environment variables in README.md, and fix the `pydev git` -> `pydev gitlab` typo there